### PR TITLE
Make microstates composable

### DIFF
--- a/src/computed-property.js
+++ b/src/computed-property.js
@@ -1,3 +1,4 @@
+import assign from './assign';
 /**
  * Property Descriptor that computes its value once and then permanently caches
  * the result.
@@ -12,12 +13,13 @@ export default class ComputedProperty {
 
   get enumerable() { return false; }
 
-  constructor(compute) {
+  constructor(compute, attributes = {}) {
     let property = this;
     this.get = function() {
       let value = compute.call(this);
       property.get = ()=> value;
       return value;
     };
+    assign(this, attributes);
   }
 }

--- a/src/computed-property.js
+++ b/src/computed-property.js
@@ -6,7 +6,50 @@ import assign from './assign';
  * In order to make the computation of microstate properties easy to
  * reason about, we want them to be as lazy as possible. However, in
  * order to make sure that we don't do any extra computation than
- * necessary.
+ * necessary we want to permanently cache the result of those lazy
+ * computations. That's where `ComputedProperty` comes in.
+ *
+ * Every instance of `ComputedProperty` is a valid instance of a
+ * JavaScript property descriptor, which, by default,  is
+ * is _not_ enumerable. It can be used in any API that expects a property
+ * descriptor. For example:
+ *
+ *   let object = {};
+ *   Object.defineProperty('constant', new ComputedProperty(function() {
+ *     return {};
+ *   }))
+ *
+ *   object.constant === object.constant //=> true
+ *
+ * In order to change the configuration of the property descriptor,
+ * you can pass a set of overrides to the constructor to do things
+ * like make it an enumerable property.
+ *
+ *   let object = {}
+ *   Object.defineProperty('constant', new ComputedProperty(function() {
+ *     return {}
+ *   }, { enumerable: true }));
+ *
+ *   Object.keys(object) //=> ['constant']
+ *
+ * The value of `this` inside the computed property evaluation function will be
+ * the object on which this property resides.
+ *
+ *   let object = {one: 1, two: 2};
+ *   Object.defineProperty('info', new ComputedProperty(function() {
+ *     return { type: typeof this, keys: Object.keys(this) };
+ *   }));
+ *
+ *   object.info //=> { type: 'object', keys: ['one', 'two'] }
+ *
+ * Note that it's totally ok to permanently cache the results of computations
+ * since the objects to which these properties will be attached are
+ * immutable.
+ *
+ * @constructor ComputedProperty
+ * @param {function} compute - evaluates the property value
+ * @param {Object} [attributes] - extra attributes for the descriptor.
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#Description
  */
 export default class ComputedProperty {
   get writeable() { return false; }

--- a/src/computed-property.js
+++ b/src/computed-property.js
@@ -13,9 +13,10 @@ export default class ComputedProperty {
   get enumerable() { return false; }
 
   constructor(compute) {
-    this.get = ()=> {
-      let value = compute();
-      this.get = ()=> value;
+    let property = this;
+    this.get = function() {
+      let value = compute.call(this);
+      property.get = ()=> value;
       return value;
     };
   }

--- a/src/computed-property.js
+++ b/src/computed-property.js
@@ -52,9 +52,6 @@ import assign from './assign';
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#Description
  */
 export default class ComputedProperty {
-  get writeable() { return false; }
-
-  get enumerable() { return false; }
 
   constructor(compute, attributes = {}) {
     let property = this;
@@ -66,3 +63,9 @@ export default class ComputedProperty {
     assign(this, attributes);
   }
 }
+
+ComputedProperty.prototype.writeable = false;
+
+ComputedProperty.prototype.configurable = false;
+
+ComputedProperty.prototype.enumerable = false;

--- a/src/extend.js
+++ b/src/extend.js
@@ -57,8 +57,8 @@ const Metadata = cached(class Metadata {
    *     two: "Another String"
    *   }
    * @method merge
-   * @param state - a hash potentially containing microstates
-   * @param attrs - a hash of simple JavaScript values.
+   * @param {object} state - a hash potentially containing microstates
+   * @param {object} attrs - a hash of simple JavaScript values.
    */
   merge(state, attrs) {
     return reduceObject(attrs, (merged, name, value)=> {
@@ -70,6 +70,19 @@ const Metadata = cached(class Metadata {
     }, state.valueOf());
   }
 
+  /**
+   * Tests if any object is a microstate.
+   *
+   * Microstates get special treament throughout the process of
+   * transitions, and so you need a way to check if an object is a
+   * microstate. When metadata is created for a microstate
+   * constructor, a reference to the very root of the microstate tree
+   * is captured in order to make this check easy.
+   *
+   * @method isMicrostate
+   * @param {object} object - the object to check
+   * @returns {boolean} if `object` is a microstate
+   */
   isMicrostate(object) {
     return object instanceof this.Microstate;
   }

--- a/src/extend.js
+++ b/src/extend.js
@@ -42,6 +42,8 @@ const Metadata = cached(class Metadata {
           let result = method.call(this, this.valueOf(), ...args);
           if (result instanceof Type) {
             return result;
+          } else if (result instanceof Object) {
+            return new Type(assign({}, this.valueOf(), result.valueOf()));
           } else {
             return new Type(result.valueOf());
           }

--- a/src/object-utils.js
+++ b/src/object-utils.js
@@ -22,7 +22,7 @@ export function reduceObject(object, fn, result = {}) {
 }
 
 export function eachProperty(object, fn) {
-  Object.getOwnPropertyNames(object).forEach(function(name) {
+  Object.keys(object).forEach(function(name) {
     fn(name, object[name]);
   });
 }

--- a/src/object-utils.js
+++ b/src/object-utils.js
@@ -2,7 +2,8 @@ import assign from './assign';
 
 /**
  * Maps over the keys of an object converting the values of those keys into new
- * objects. E.g.
+ * objects. The return value will be an object with the same set of
+ * keys, but a different set of values. E.g.
  *
  * > mapObject({first: 1, second: 2}, (value)=> value *2)
  *

--- a/src/object-utils.js
+++ b/src/object-utils.js
@@ -1,0 +1,28 @@
+import assign from './assign';
+
+/**
+ * Maps over the keys of an object converting the values of those keys into new
+ * objects. E.g.
+ *
+ * > mapObject({first: 1, second: 2}, (value)=> value *2)
+ *
+ *   {first: 2, second: 4}
+ */
+export function mapObject(object = {}, fn) {
+  return reduceObject(object, function(result, name, value) {
+    return assign(result, { [name]: fn(name, value) });
+  });
+}
+
+export function reduceObject(object, fn, result = {}) {
+  eachProperty(object, function(name, value) {
+    result = fn(result, name, value);
+  });
+  return result;
+}
+
+export function eachProperty(object, fn) {
+  Object.getOwnPropertyNames(object).forEach(function(name) {
+    fn(name, object[name]);
+  });
+}

--- a/src/state.js
+++ b/src/state.js
@@ -5,12 +5,12 @@ import { reduceObject } from './object-utils';
 class Opaque {
   constructor(value) {
     let metadata = this.constructor.metadata;
-    metadata.construct(Opaque, this, value);
+    metadata.construct(this, value);
     Object.freeze(this);
   }
 
   static extend(properties) {
-    return extend(this, properties);
+    return extend(Opaque, this, properties);
   }
 }
 

--- a/src/state.js
+++ b/src/state.js
@@ -1,24 +1,34 @@
 import assign from './assign';
-import Metadata from './metadata';
+import extend, { contextualize } from './extend';
+
+const { keys, defineProperty } = Object;
 
 class Opaque {
   constructor(value) {
     if (value instanceof Object) {
-      assign(this, value.valueOf());
+      keys(value).forEach((key)=> {
+        defineProperty(this, key, new ValueProperty(this, key, value));
+      });
     }
     Object.defineProperty(this, 'valueOf', {
-      value() { return value.valueOf(); },
+      value() {
+        let unboxed = value.valueOf();
+        return Object.keys(unboxed).reduce(function(valueOf, key) {
+          let prop = unboxed[key];
+          if (prop instanceof Opaque) {
+            return assign({}, valueOf, { [key]: prop.valueOf() });
+          } else {
+            return valueOf;
+          }
+        }, unboxed);
+      },
       enumerable: false
     });
     Object.freeze(this);
   }
 
   static extend(properties) {
-    let Type = class State extends this {};
-    let metadata = new Metadata(Type, this, properties);
-    Type.metadata = metadata;
-    Type.prototype = metadata.prototype;
-    return Type;
+    return extend(this, properties);
   }
 }
 
@@ -41,3 +51,32 @@ export default Opaque.extend({
     }
   }
 });
+
+
+import ComputedProperty from './computed-property';
+
+class ValueProperty extends ComputedProperty {
+  enumerable() { return true; }
+
+  constructor(container, key, attributes) {
+    super(function() {
+      let value = attributes[key];
+      if (value instanceof Opaque) {
+        return contextualize(value, container, key);
+      } else {
+        return value;
+      }
+    });
+  }
+}
+
+class NestedTransition extends ComputedProperty {
+  constructor(container, key) {
+    super(function() {
+      return function(...args) {
+        let result = this.super[key](...args);
+        return container.put(key, result);
+      };
+    });
+  }
+}

--- a/src/state.js
+++ b/src/state.js
@@ -1,5 +1,6 @@
 import assign from './assign';
 import extend from './extend';
+import { reduceObject } from './object-utils';
 
 class Opaque {
   constructor(value) {
@@ -19,16 +20,15 @@ export default Opaque.extend({
       return new this.constructor(value);
     },
     assign(current, attrs) {
-      return assign({}, current, attrs);
+      return attrs;
     },
     put(current, key, value) {
-      return assign({}, current, { [key]: value});
+      return { [key]: value };
     },
     delete(current, key) {
-      let keys = Object.keys(current).filter(k => k !== key);
-      return keys.reduce((next, key)=> {
-        return assign(next, { [key]: current[key] });
-      }, {});
+      return this.set(reduceObject(current, (attrs, name, value)=> {
+        return name === key ? attrs : assign(attrs, { [name]: value });
+      }));
     }
   }
 });

--- a/src/state.js
+++ b/src/state.js
@@ -69,14 +69,3 @@ class ValueProperty extends ComputedProperty {
     });
   }
 }
-
-class NestedTransition extends ComputedProperty {
-  constructor(container, key) {
-    super(function() {
-      return function(...args) {
-        let result = this.super[key](...args);
-        return container.put(key, result);
-      };
-    });
-  }
-}

--- a/test/composition-test.js
+++ b/test/composition-test.js
@@ -83,4 +83,60 @@ describe("Composition", function() {
       });
     });
   });
+
+  describe("deep, deep, nesting", function() {
+    let Zero, One, Two, Three, zero;
+    beforeEach(function() {
+      Three = State.extend({});
+      Two = State.extend({
+        three: new Three(3)
+      });
+      One = State.extend({
+        two: new Two()
+      });
+      Zero = State.extend({
+        one: new One()
+      });
+      zero = new Zero();
+    });
+    it("serializes its value", function() {
+      expect(zero.valueOf()).to.deep.equal({
+        one: {
+          two: {
+            three: 3
+          }
+        }
+      });
+    });
+    describe("constructed with a single JSON object", function() {
+      beforeEach(function() {
+        zero = new Zero({one: {two: {three: 'Go'}}});
+      });
+      it("reserializes to the same value", function() {
+        expect(zero.valueOf()).to.deep.equal({one: {two: {three: 'Go'}}});
+      });
+      it("can transition properly", function() {
+        expect(zero.one.two.three.set('Go Loco').valueOf()).to.deep.equal({
+          one: {
+            two: {
+              three: 'Go Loco'
+            }
+          }
+        });
+      });
+    });
+
+    describe("invoking a transition on a sub-object", function() {
+      let next;
+      beforeEach(function() {
+        let three = zero.one.two.three;
+        next = three.set(5);
+      });
+      it("returns an instance of the root state corresponding to the transition", function() {
+        expect(next).to.be.instanceOf(Zero);
+        expect(next.valueOf()).to.deep.equal({one: {two: {three: 5}}});
+      });
+    });
+
+  });
 });

--- a/test/composition-test.js
+++ b/test/composition-test.js
@@ -1,0 +1,51 @@
+import { describe, beforeEach, it } from 'mocha';
+import { expect } from 'chai';
+
+import State from '../src/state';
+
+describe("Composition", function() {
+
+  const Switch = State.extend({
+    transitions: {
+      toggle(current) {
+        return !current;
+      }
+    }
+  });
+
+  let _true = new Switch(true);
+  let _false = new Switch(false);
+
+  let switchboard = new State({
+    left: _true,
+    right: _false
+  });
+
+  it("starts out with the left true and the right false", function() {
+    expect(switchboard.valueOf()).to.deep.equal({
+      left: true,
+      right: false
+    });
+  });
+
+  it("lets you toggle switches individually", function() {
+    expect(_true.toggle().valueOf()).to.equal(false);
+    expect(_false.toggle().valueOf()).to.equal(true);
+  });
+
+  describe("toggling the left switch", function() {
+    let next;
+    beforeEach(function() {
+      next = switchboard.left.toggle();
+    });
+    it("returns a new switchboard with the left toggled", function() {
+      expect(next.valueOf()).to.deep.equal({
+        left: false,
+        right: false
+      });
+    });
+    it("did not change _true", function() {
+      expect(_true.valueOf()).to.equal(true);
+    });
+  });
+});

--- a/test/metadata-test.js
+++ b/test/metadata-test.js
@@ -1,0 +1,27 @@
+import { describe, beforeEach, it } from 'mocha';
+import { expect } from 'chai';
+
+import State from '../src/state';
+
+describe("Metadata", function() {
+  it("has a list of own transitions", function() {
+    expect(Object.keys(State.metadata.transitions)).to.deep.equal(['set', 'assign', 'put', 'delete']);
+  });
+
+  describe("of a subtype", function() {
+    let Type = State.extend({
+      transitions: {
+        one() { return 1; }
+      }
+    }).extend({
+      transitions: {
+        two() { return 2; }
+      }
+    });
+    it("contains the transitions of all types", function() {
+      expect(Object.keys(Type.metadata.transitions)).to.deep.equal(['two', 'one', 'set', 'assign', 'put', 'delete']);
+    });
+
+  });
+
+});

--- a/test/state-test.js
+++ b/test/state-test.js
@@ -121,6 +121,10 @@ describe("The Basic Opaque State", function() {
         expect(thing.two).to.equal(2);
       });
 
+      it("has those values in its valueOf()", function() {
+        expect(thing.valueOf()).to.deep.equal({one: 1, two: 2});
+      });
+
       describe("assigning to one of the values", function() {
         let next;
         beforeEach(function() {

--- a/test/state-test.js
+++ b/test/state-test.js
@@ -106,6 +106,39 @@ describe("The Basic Opaque State", function() {
       });
     });
 
+    describe("with pre-defined properties", function() {
+      const Thing = State.extend({
+        one: 1,
+        two: 2
+      });
+      let thing;
+      beforeEach(function() {
+        thing = new Thing();
+      });
+
+      it("has those properties by default", function() {
+        expect(thing.one).to.equal(1);
+        expect(thing.two).to.equal(2);
+      });
+
+      describe("assigning to one of the values", function() {
+        let next;
+        beforeEach(function() {
+          next = thing.assign({ one: 'one'});
+        });
+
+        it("changes the value of the one property", function() {
+          expect(next.one).to.equal('one');
+        });
+        it("leaves the unassigned value alone", function() {
+          expect(next.two).to.equal(2);
+        });
+        it("does not change the original (of course)", function() {
+          expect(thing.one).to.equal(1);
+        });
+      });
+    });
+
     describe("trying to manipulate properties directly on a state", function() {
       let edit, add, remove;
       beforeEach(function() {
@@ -119,6 +152,5 @@ describe("The Basic Opaque State", function() {
         expect(remove).to.be.instanceof(TypeError);
       });
     });
-
   });
 });

--- a/test/transition-test.js
+++ b/test/transition-test.js
@@ -1,0 +1,26 @@
+import { describe, beforeEach, it } from 'mocha';
+import { expect } from 'chai';
+
+import State from '../src/state';
+
+describe("Transitions", function() {
+  describe("transitions that only 'patch' an object", function() {
+    let switchboard;
+    beforeEach(function() {
+      const Switchboard = State.extend({
+        transitions: {
+          toggleLeft(current) {
+            return { left: !current.left };
+          },
+          toggleRight(current) {
+            return { right: !current.right };
+          }
+        }
+      });
+      switchboard = new Switchboard({left: false, right: false});
+    });
+    it("applies the 'patch', and leaves the other properties in place", function() {
+      expect(switchboard.toggleLeft().valueOf()).to.deep.equal({left: true, right: false});
+    });
+  });
+});

--- a/test/transition-test.js
+++ b/test/transition-test.js
@@ -8,6 +8,8 @@ describe("Transitions", function() {
     let switchboard;
     beforeEach(function() {
       const Switchboard = State.extend({
+        left: false,
+        right: false,
         transitions: {
           toggleLeft(current) {
             return { left: !current.left };
@@ -17,8 +19,9 @@ describe("Transitions", function() {
           }
         }
       });
-      switchboard = new Switchboard({left: false, right: false});
+      switchboard = new Switchboard();
     });
+
     it("applies the 'patch', and leaves the other properties in place", function() {
       expect(switchboard.toggleLeft().valueOf()).to.deep.equal({left: true, right: false});
     });


### PR DESCRIPTION
This adds the ability to nest microstates within other microstates, and to invoke transitions on nested microstates that will return a new version of the entire datastructure.

```js

let state = new State({
  one: new State({
    two: new State({
      three: new State(3)
    })
  })
});
```

The `valueOf()` method for the super-state will return a recursively unboxed value of all the states:

```js
state.valueOf() //=> {one: {two: {three: 3}}}
```

State transitions can be invoked at any level of the tree, but will result in a global state transition:

```js
let next = state.one.two.three.set('three')
next === state //=> false
next.valueOf() //= {one: {two: {three: 'three'}}}
```

But the original state remains unchanged:

```js
state.valueOf() //=> {one: {two: {three: 3}}}
```
