### PR TITLE
Tight box microstate

### DIFF
--- a/src/box.js
+++ b/src/box.js
@@ -1,0 +1,5 @@
+import State from './state';
+
+export default function box(value) {
+  return new State(value);
+}

--- a/src/computed-property.js
+++ b/src/computed-property.js
@@ -56,9 +56,11 @@ export default class ComputedProperty {
   constructor(compute, attributes = {}) {
     let property = this;
     this.get = function() {
-      let value = compute.call(this);
-      property.get = ()=> value;
-      return value;
+      if (!property.isComputed) {
+        property.cache = compute.call(this);
+        property.isComputed = true;
+      }
+      return property.cache;
     };
     assign(this, attributes);
   }

--- a/src/object-utils.js
+++ b/src/object-utils.js
@@ -23,7 +23,9 @@ export function reduceObject(object, fn, result = {}) {
 }
 
 export function eachProperty(object, fn) {
-  Object.keys(object).forEach(function(name) {
-    fn(name, object[name]);
-  });
+  if (typeof object === 'object') {
+    Object.keys(object).forEach(function(name) {
+      fn(name, object[name]);
+    });
+  }
 }

--- a/test/state-test.js
+++ b/test/state-test.js
@@ -26,8 +26,12 @@ describe("The Basic Opaque State", function() {
       state = new State(object);
     });
 
-    it("has that object as its primitive value", function() {
-      expect(state.valueOf()).to.eq(object);
+    it("has an equivalent object as its valueOf()", function() {
+      expect(state.valueOf()).to.deep.equal(object);
+    });
+
+    it('maintains the valueOf across subsequent invocations', function() {
+      expect(state.valueOf()).to.equal(state.valueOf());
     });
 
     it("has the enumerable keys of the object value", function() {
@@ -35,8 +39,10 @@ describe("The Basic Opaque State", function() {
     });
 
     it("has the same property values as the object value", function() {
-      expect(state.ohai).to.equal('There');
-      expect(state.hello).to.equal('World');
+      expect(state.ohai).to.be.instanceof(State);
+      expect(state.hello).to.be.instanceof(State);
+      expect(state.ohai.valueOf()).to.equal('There');
+      expect(state.hello.valueOf()).to.equal('World');
     });
 
     describe("setting the value to a new object", function() {
@@ -52,7 +58,7 @@ describe("The Basic Opaque State", function() {
         expect(next.hello).to.equal(undefined);
       });
       it("has the properties of the new object", function() {
-        expect(next.totally).to.equal('different');
+        expect(next.totally.valueOf()).to.equal('different');
       });
       it("has the enumerable keys of the new object", function() {
         expect(Object.keys(next)).to.deep.equal(['totally']);
@@ -64,11 +70,11 @@ describe("The Basic Opaque State", function() {
         next = state.assign({ how: 'do you do?'});
       });
       it("maintains the list of old properties", function() {
-        expect(next.ohai).to.equal('There');
-        expect(next.hello).to.equal('World');
+        expect(next.ohai.valueOf()).to.equal('There');
+        expect(next.hello.valueOf()).to.equal('World');
       });
       it("adds the new property", function() {
-        expect(next.how).to.equal('do you do?');
+        expect(next.how.valueOf()).to.equal('do you do?');
       });
       it("has the new enumerable key", function() {
         expect(Object.keys(next)).to.deep.equal(['ohai', 'hello', 'how']);
@@ -80,11 +86,11 @@ describe("The Basic Opaque State", function() {
         next = state.put('how', 'do you do?');
       });
       it("maintains the list of old properties", function() {
-        expect(next.ohai).to.equal('There');
-        expect(next.hello).to.equal('World');
+        expect(next.ohai.valueOf()).to.equal('There');
+        expect(next.hello.valueOf()).to.equal('World');
       });
       it("adds the new property", function() {
-        expect(next.how).to.equal('do you do?');
+        expect(next.how.valueOf()).to.equal('do you do?');
       });
       it("has the new enumerable key", function() {
         expect(Object.keys(next)).to.deep.equal(['ohai', 'hello', 'how']);
@@ -99,7 +105,7 @@ describe("The Basic Opaque State", function() {
         expect(next.ohai).to.equal(undefined);
       });
       it("maintains the other properties", function() {
-        expect(next.hello).to.equal('World');
+        expect(next.hello.valueOf()).to.equal('World');
       });
       it("only has the remaining property name in its enumerable ", function() {
         expect(Object.keys(next)).to.deep.equal(['hello']);
@@ -107,18 +113,21 @@ describe("The Basic Opaque State", function() {
     });
 
     describe("with pre-defined properties", function() {
-      const Thing = State.extend({
-        one: 1,
-        two: 2
-      });
-      let thing;
+
+      let Thing, thing, value;
       beforeEach(function() {
+        Thing = State.extend({
+          one: 1,
+          two: 2
+        });
         thing = new Thing();
       });
 
       it("has those properties by default", function() {
-        expect(thing.one).to.equal(1);
-        expect(thing.two).to.equal(2);
+        expect(thing.one).to.be.instanceOf(State);
+        expect(thing.two).to.be.instanceOf(State);
+        expect(thing.one.valueOf()).to.equal(1);
+        expect(thing.two.valueOf()).to.equal(2);
       });
 
       it("has those values in its valueOf()", function() {
@@ -128,17 +137,17 @@ describe("The Basic Opaque State", function() {
       describe("assigning to one of the values", function() {
         let next;
         beforeEach(function() {
-          next = thing.assign({ one: 'one'});
+          next = thing.assign({ one: 'one'}).valueOf();
         });
 
         it("changes the value of the one property", function() {
-          expect(next.one).to.equal('one');
+          expect(next.one.valueOf()).to.equal('one');
         });
         it("leaves the unassigned value alone", function() {
-          expect(next.two).to.equal(2);
+          expect(next.two.valueOf()).to.equal(2);
         });
         it("does not change the original (of course)", function() {
-          expect(thing.one).to.equal(1);
+          expect(thing.one.valueOf()).to.equal(1);
         });
       });
     });


### PR DESCRIPTION
There was a lot of conflict surrounding whether an object was a microstate, or whether an object was a microstate value. Sometimes a microstate acted like the properties it wrapped, and sometimes it acted as the state machine box that it is.

This enforces a clean separation between the microstate and its value. All values in a microstate are now wrapped in contextualized microstates, and the microstate forms an impenetrable box around its properties. The only way to "unbox" the value of a microstate is to call its `valueOf` method. E.g.

```js
let switchboard = new State({
  left: true,
  right: true
});

let leftOff = switchboard.left.set(false);
let rightOff = switchboard.right.set(false);

rightOff.valueOf() //=> { left: true, right: false }
rightOff.right.valueOf() //=> false.
```

In the cases where microstates are comprised of other microstates, it will ensure boxing in the microstate constructor currently occupying a particular slot.

```js
const Switch = new State({
  transitions: {
    toggle(current) {
      return !!current;
    }
  }
});

let board = new State({left: new Switch(false), right: new Switch(false)});
let leftOn = board.put({left: true}); //put a boolean
let allOff = board.left.toggle(); // but it is still a `Switch`
```

It might be worth noting that to support this, the value exiting the box vs the value entering the box are not the same unless it is a primitive value. This is because the valueOf computation is lazy and will only materialize the subtrees as they are requested.

```js
let object = {one: 'two'};
new State(object).valueOf() === object //=> false
```

We can return to this behavior, i.e. preserve the value if nothing has changed, but it would mean a depth first traversal of the entire value tree in order to search for changes, so I decided to err on the side of computational laziness.