### PR TITLE
Overloadable value of

### DIFF
--- a/src/extend.js
+++ b/src/extend.js
@@ -195,8 +195,8 @@ class ChildProperty extends ComputedProperty {
 class ValueOfMethod extends ComputedProperty {
   constructor(metadata, state, value, descriptors) {
     /**
-     * function returns the value that computed property will cache
-     * (iow, this return value is the value of this computed property)
+     * super receives a function that will return the valueOf this microstate.
+     * The returned value is cached by ComputedProperty.
      */
     super(function() {
       let valueOf = compute();

--- a/test/state-test.js
+++ b/test/state-test.js
@@ -233,4 +233,25 @@ describe("The Basic Opaque State", function() {
       });
   });
 
+  describe("inheriting valueOf", function() {
+    let Taras; 
+    beforeEach(function(){
+      let Person = State.extend({
+        valueOf(value) {
+          return {
+            name: `${value.firstName} ${value.lastName}`
+          };
+        }
+      }).extend({});
+
+      Taras = new Person({
+        firstName: 'Taras',
+        lastName: 'Mankovski'
+      });
+    });
+    it.skip('inherits valueOf from parent', function(){
+      expect(Taras.valueOf()).to.deep.equal({ name: 'Taras Mankovski' });
+    });
+  });
+
 });

--- a/test/state-test.js
+++ b/test/state-test.js
@@ -208,7 +208,29 @@ describe("The Basic Opaque State", function() {
           b: {c: '<li>Bob</li>'}
         });
       });
-      
     });
   });
+
+  describe("exporting properties from prototypes", function() {
+      let Speaker, LolSpeaker;
+      beforeEach(function(){
+        Speaker = State.extend({
+          message: 'hello world'
+        });
+
+        LolSpeaker = Speaker.extend({
+          valueOf(value) {
+            return {
+              message: `hehe ${value.message} hehe`
+            };
+          }
+        });
+      });
+
+      it.skip('has different valueOf', function(){
+        expect(new Speaker().valueOf()).to.deep.equal({ message: 'hello world' }); 
+        expect(new LolSpeaker().valueOf()).to.deep.equal({ message: 'hehe hello world hehe'});
+      });
+  });
+
 });

--- a/test/state-test.js
+++ b/test/state-test.js
@@ -184,5 +184,31 @@ describe("The Basic Opaque State", function() {
         expect(lols.valueOf()).to.deep.equal({ message: 'hehe hello world hehe'});
       });
     });
+
+    describe('access to deeply nested microstates', function() {
+      let AState, BState;
+      beforeEach(function() {
+
+        BState = State.extend({
+          c: new State('Bob'),
+          valueOf(value) {
+            return {
+              c: `<li>${value.c}</li>`
+            };
+          }
+        });
+
+        AState = State.extend({
+          b: new BState()
+        });
+
+      });
+      it('uses customized valueOf', function() {
+        expect(new AState().valueOf()).to.deep.equal({
+          b: {c: '<li>Bob</li>'}
+        });
+      });
+      
+    });
   });
 });

--- a/test/state-test.js
+++ b/test/state-test.js
@@ -169,24 +169,18 @@ describe("The Basic Opaque State", function() {
     describe("overloading valueOf", function() {
       let Speaker, LolSpeaker, said, lols;
       beforeEach(function(){
-        Speaker = State.extend({
-          message: 'hello world'
-        });
-
-        LolSpeaker = Speaker.extend({
-          valueOf() {
+        LolSpeaker = State.extend({
+          valueOf(value) {
             return {
-              message: `hehe ${this.message} hehe`
+              message: `hehe ${value.message} hehe`
             };
           }
         });
 
-        said = new Speaker().valueOf();
-        lols = new LolSpeaker().valueOf();
+        lols = new LolSpeaker({message: 'hello world'});
       });
 
-      it.only('has different valueOf', function(){
-        expect(said.valueOf()).to.deep.equal({ meesage: 'hello world' }); 
+      it('has different valueOf', function(){
         expect(lols.valueOf()).to.deep.equal({ message: 'hehe hello world hehe'});
       });
     });

--- a/test/state-test.js
+++ b/test/state-test.js
@@ -165,5 +165,30 @@ describe("The Basic Opaque State", function() {
         expect(remove).to.be.instanceof(TypeError);
       });
     });
+
+    describe("overloading valueOf", function() {
+      let Speaker, LolSpeaker, said, lols;
+      beforeEach(function(){
+        Speaker = State.extend({
+          message: 'hello world'
+        });
+
+        LolSpeaker = Speaker.extend({
+          valueOf() {
+            return {
+              message: `hehe ${this.message} hehe`
+            };
+          }
+        });
+
+        said = new Speaker().valueOf();
+        lols = new LolSpeaker().valueOf();
+      });
+
+      it.only('has different valueOf', function(){
+        expect(said.valueOf()).to.deep.equal({ meesage: 'hello world' }); 
+        expect(lols.valueOf()).to.deep.equal({ message: 'hehe hello world hehe'});
+      });
+    });
   });
 });


### PR DESCRIPTION
This pull request adds the ability to overload the valueOf method on a microstate class. The valueOf method receives boxed in value of the microstate and returns that value for the default implementation.

```js
let MyState = State.extend({
  happy: new State(true)
  valueOf(value) {
    return {
      feeling: value.happy ? "😀" : "😧"
    }
  }
})
```

This PR includes 2 failing tests:
- access to prototype values in valueOf
- inherited custom valueOf