### PR TITLE
Simplified getValue by removing initializer

### DIFF
--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -1,3 +1,5 @@
+import { CurriedFunction1 } from 'ramda/src/$curriedFunctions';
+
 import MicrostateBoolean from './primitives/boolean';
 import MicrostateArray from './primitives/array';
 import MicrostateString from './primitives/string';
@@ -16,6 +18,7 @@ export interface IMicrostate {
 }
 
 export interface ITransitionMap {
+  initialize?: (...args: any[]) => any;
   [name: string]: (current: any, ...args: Array<any>) => any;
 }
 
@@ -62,3 +65,5 @@ export interface ITypeTree {
 export interface ITypeTreeProperties {
   [name: string]: ITypeTree;
 }
+
+export type CurriedGetValue = CurriedFunction1<(string | number)[], any>;

--- a/src/primitives/array.ts
+++ b/src/primitives/array.ts
@@ -1,5 +1,5 @@
 export default class MicrostateArray extends Array {
-  static initialize = (current: Array<any>, newState: any) => newState || [];
+  static initialize = (): any[] => [];
 
   static push = (current: Array<any>, ...args: Array<any>) => [...current, ...args];
 }

--- a/src/primitives/boolean.ts
+++ b/src/primitives/boolean.ts
@@ -1,5 +1,5 @@
 export default class MicrostateBoolean extends Boolean {
-  static initialize = (current: {}, newState: any) => newState || false;
+  static initialize = () => false;
 
   static toggle = (current: boolean) => !current;
 }

--- a/src/primitives/number.ts
+++ b/src/primitives/number.ts
@@ -1,5 +1,5 @@
 export default class MicrostateNumber extends Number {
-  static initialize = (current: Number, newState: any) => newState | 0;
+  static initialize = () => 0;
 
   static sum = (current: number, ...args: Array<number>) =>
     args.reduce((accumulator, value) => accumulator + value, current);

--- a/src/primitives/object.ts
+++ b/src/primitives/object.ts
@@ -1,5 +1,5 @@
 export default class MicrostateObject extends Object {
-  static initialize = (current: {}, newState: any) => newState || {};
+  static initialize = () => ({});
 
   static assign = (current: {}, props: {}) => ({
     ...current,

--- a/src/primitives/string.ts
+++ b/src/primitives/string.ts
@@ -1,7 +1,5 @@
 export default class MicrostateString extends String {
-  static initialize = function initialize(current: string, newState: any) {
-    return newState || '';
-  };
+  static initialize = () => '';
 
   static concat = function concat(current: string, ...args: Array<string>) {
     return String.prototype.concat.apply(current, args);

--- a/src/utils/getValueFactory.ts
+++ b/src/utils/getValueFactory.ts
@@ -3,21 +3,12 @@ import * as lensPath from 'ramda/src/lensPath';
 import * as set from 'ramda/src/set';
 import * as view from 'ramda/src/view';
 import * as curry from 'ramda/src/curry';
-import { CurriedFunction2 } from 'ramda/src/$curriedFunctions';
 
-import { IPath, ITransition } from '../Interfaces';
+import { IPath, ITransition, CurriedGetValue } from '../Interfaces';
 
-export default function getValueFactory(
-  state: any
-): CurriedFunction2<ITransition, (string | number)[], any> {
-  return curry(function getValue(initialize: ITransition, path: IPath, state: any) {
+export default function getValueFactory(state: any): CurriedGetValue {
+  return curry(function getValue(path: IPath, state: any) {
     let lens = lensPath(path);
-    let value = view(lens, state);
-
-    if (initialize) {
-      return value || initialize(value);
-    } else {
-      return value;
-    }
-  })(__, __, state);
+    return view(lens, state);
+  })(__, state);
 }

--- a/tests/utils/mapState.test.ts
+++ b/tests/utils/mapState.test.ts
@@ -12,8 +12,8 @@ describe('mapState', () => {
       it('invoked callback', () => {
         expect(callback.mock.calls).toHaveProperty('length', 1);
       });
-      it('passed path to second argumetn', () => {
-        expect(callback.mock.calls[0][1]).toEqual([]);
+      it('passed path to first argument', () => {
+        expect(callback.mock.calls[0][0]).toEqual([]);
       });
       it('returns value', () => {
         expect(state).toBe('foo');


### PR DESCRIPTION
* getValue no longer received an initializer as the first argument
* initializer is called explicitly in mapState
* initializer no longer expects `(current, newState) => newState`
* simplified initializer to just return initialized value