### PR TITLE
Create States and Transitions builder functions

### DIFF
--- a/src/microstates.js
+++ b/src/microstates.js
@@ -1,39 +1,12 @@
-import { append, map } from 'funcadelic';
-import lensPath from 'ramda/src/lensPath';
-
-import gettersFor from './utils/getters-for';
-import initialize from './utils/initialize';
-import isPrimitive from './utils/is-primitive';
-import transitionsFor from './utils/transitions-for';
 import Tree from './utils/tree';
+import States from './utils/states';
+import Transitions from './utils/transitions';
 import validate from './utils/validate';
 
 export default class Microstates {
   constructor(tree, value) {
-    let values = map(data => append(data, { value: initialize(data, value) }), tree);
-
-    this.states = map(
-      ({ Type, value }) => (isPrimitive(Type) ? value : append(value, gettersFor(Type))),
-      values
-    ).collapsed;
-
-    // raw, uncurried transitions
-    let rawTransitions = map(
-      ({ Type, path }) => ({ path, transitions: transitionsFor(Type) }),
-      tree
-    );
-
-    // curry in the lens and value
-    let curriedTransitions = map(
-      ({ path, transitions }) =>
-        map(
-          t => (...args) => t(lensPath(path), map(({ value }) => value, values).collapsed, ...args),
-          transitions
-        ),
-      rawTransitions
-    );
-
-    this.transitions = curriedTransitions.collapsed;
+    this.states = States(tree, value);
+    this.transitions = Transitions(tree, this.states);
     this.tree = tree;
   }
   /**

--- a/src/utils/states.js
+++ b/src/utils/states.js
@@ -1,0 +1,12 @@
+import { append, map } from 'funcadelic';
+
+import initialize from './initialize';
+import isPrimitive from './is-primitive';
+import gettersFor from './getters-for';
+
+export default function States(tree, value) {
+  return map(
+    ({ Type, value }) => (isPrimitive(Type) ? value : append(value, gettersFor(Type))),
+    map(data => append(data, { value: initialize(data, value) }), tree)
+  ).collapsed;
+}

--- a/src/utils/transitions.js
+++ b/src/utils/transitions.js
@@ -1,0 +1,13 @@
+import lensPath from 'ramda/src/lensPath';
+import { map } from 'funcadelic';
+
+import transitionsFor from './transitions-for';
+
+export default function Transitions(tree, states) {
+  return map(
+    ({ path, transitions }) =>
+      map(t => (...args) => t(lensPath(path), states, ...args), transitions),
+    // curried transitions
+    map(({ Type, path }) => ({ path, transitions: transitionsFor(Type) }), tree)
+  ).collapsed;
+}


### PR DESCRIPTION
This PR moves the logic used to generate States and Transitions to their own files. This will make it easier to implement transition context.