### PR TITLE
States tree should have nodes using their types

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "standard-version": "^4.2.0"
   },
   "dependencies": {
-    "funcadelic": "^0.2.2",
+    "funcadelic": "^0.2.5",
     "object.getownpropertydescriptors": "2.0.3",
     "ramda": "^0.24.1"
   },

--- a/src/microstates.js
+++ b/src/microstates.js
@@ -5,8 +5,8 @@ import validate from './utils/validate';
 
 export default class Microstates {
   constructor(tree, value) {
-    this.states = States(tree, value);
-    this.transitions = Transitions(tree, this.states);
+    this.states = States(tree, value).collapsed;
+    this.transitions = Transitions(tree, this.states).collapsed;
     this.tree = tree;
   }
   /**

--- a/src/utils/getters-for.js
+++ b/src/utils/getters-for.js
@@ -5,7 +5,7 @@ export default function gettersFor(Type) {
   let descriptors = filter(({ value }) => !!value.get, getOwnPropertyDescriptors(Type.prototype));
 
   return Object.create(
-    Object.prototype,
+    Type.prototype,
     map(descriptor => append(descriptor, { enumerable: true }), descriptors)
   );
 }

--- a/src/utils/states.js
+++ b/src/utils/states.js
@@ -6,7 +6,7 @@ import gettersFor from './getters-for';
 
 export default function States(tree, value) {
   return map(
-    ({ Type, value }) => (isPrimitive(Type) ? value : append(value, gettersFor(Type))),
+    ({ Type, value }) => (isPrimitive(Type) ? value : append(gettersFor(Type), value)),
     map(data => append(data, { value: initialize(data, value) }), tree)
   ).collapsed;
 }

--- a/src/utils/states.js
+++ b/src/utils/states.js
@@ -6,7 +6,7 @@ import gettersFor from './getters-for';
 
 export default function States(tree, value) {
   return map(
-    ({ Type, value }) => (isPrimitive(Type) ? value : append(gettersFor(Type), value)),
+    ({ Type, value }) => (isPrimitive(Type) ? value : append(value, gettersFor(Type))),
     map(data => append(data, { value: initialize(data, value) }), tree)
   );
 }

--- a/src/utils/states.js
+++ b/src/utils/states.js
@@ -8,5 +8,5 @@ export default function States(tree, value) {
   return map(
     ({ Type, value }) => (isPrimitive(Type) ? value : append(gettersFor(Type), value)),
     map(data => append(data, { value: initialize(data, value) }), tree)
-  ).collapsed;
+  );
 }

--- a/src/utils/transitions.js
+++ b/src/utils/transitions.js
@@ -9,5 +9,5 @@ export default function Transitions(tree, states) {
       map(t => (...args) => t(lensPath(path), states, ...args), transitions),
     // curried transitions
     map(({ Type, path }) => ({ path, transitions: transitionsFor(Type) }), tree)
-  ).collapsed;
+  );
 }

--- a/src/utils/tree.js
+++ b/src/utils/tree.js
@@ -12,6 +12,7 @@ export default class Tree {
 
   get collapsed() {
     if (keys(this.children).length > 0) {
+      console.log(this.data);
       return append(this.data, map(child => child.collapsed, this.children));
     } else {
       return this.data;

--- a/src/utils/tree.js
+++ b/src/utils/tree.js
@@ -12,7 +12,6 @@ export default class Tree {
 
   get collapsed() {
     if (keys(this.children).length > 0) {
-      console.log(this.data);
       return append(this.data, map(child => child.collapsed, this.children));
     } else {
       return this.data;

--- a/tests/microstates.test.js
+++ b/tests/microstates.test.js
@@ -44,6 +44,9 @@ describe('microstates', () => {
       beforeEach(() => {
         ms = Microstates.from(State);
       });
+      it('is instance of State', () => {
+        expect(ms.states).toBeInstanceOf(State);
+      });
       it('initializes default', () => {
         expect(ms).toHaveProperty('states', { name: '', isOpen: false });
       });

--- a/tests/utils/getters-for.test.js
+++ b/tests/utils/getters-for.test.js
@@ -21,4 +21,8 @@ describe('gettersFor', () => {
       b: 'b',
     });
   });
+  it('returns instance of Type', () => {
+    class Type {}
+    expect(gettersFor(Type)).toBeInstanceOf(Type);
+  });
 });


### PR DESCRIPTION
This adds a test that node type is maintained in states tree.

It's currently failing and will pass when https://github.com/cowboyd/funcadelic.js/pull/4 is merged.