### PR TITLE
Using Microstates as an immutable data structure without predefined Types

### DIFF
--- a/src/utils/descriptors-for.js
+++ b/src/utils/descriptors-for.js
@@ -1,0 +1,11 @@
+import { append } from 'funcadelic';
+import getOwnPropertyDescriptors from 'object.getownpropertydescriptors';
+
+const { keys } = Object;
+
+export default function descriptorsFor(obj) {
+  let descriptors = getOwnPropertyDescriptors(obj);
+  return keys(descriptors).reduce((acc, name) => {
+    return [...acc, append({ name }, descriptors[name])];
+  }, []);
+}

--- a/src/utils/state.js
+++ b/src/utils/state.js
@@ -13,6 +13,10 @@ import initialize from './initialize';
 import typeLensPath from './type-lens-path';
 
 export default function state(root, value) {
+  if (typeof root !== 'function' && value === undefined) {
+    value = root;
+  }
+
   let tree = Tree.from(root);
 
   let state = map(({ Type, path }) => initialize(Type, view(lensPath(path), value)), tree);

--- a/tests/microstate.test.js
+++ b/tests/microstate.test.js
@@ -751,4 +751,44 @@ describe('microstate', () => {
       ).toBeInstanceOf(Armed);
     });
   });
+  describe('with value', () => {
+    it('from a number', () => {
+      let ms = microstate(42);
+
+      expect(ms.state).toBe(42);
+      expect(ms).toMatchObject({
+        increment: expect.any(Function),
+      });
+    });
+    describe('from an object', () => {
+      let ms = microstate({ character: { name: 'Peter Griffin', age: 64 } });
+      it('has state', () => {
+        expect(ms.state).toMatchObject({
+          character: {
+            name: 'Peter Griffin',
+            age: 64,
+          },
+        });
+      });
+      it('has transitions', () => {
+        expect(ms).toMatchObject({
+          character: {
+            name: {
+              concat: expect.any(Function),
+            },
+            age: {
+              increment: expect.any(Function),
+            },
+          },
+        });
+      });
+      it('transitions', () => {
+        expect(ms.character.age.increment().state).toMatchObject({
+          character: {
+            age: 65,
+          },
+        });
+      });
+    });
+  });
 });

--- a/tests/utils/tree.test.js
+++ b/tests/utils/tree.test.js
@@ -1,5 +1,6 @@
 import 'jest';
 
+import * as MS from '../../src';
 import Tree from '../../src/utils/tree';
 
 describe('utils/tree', () => {
@@ -7,5 +8,84 @@ describe('utils/tree', () => {
     expect(() => {
       new Tree();
     }).not.toThrow();
+  });
+  describe('from', () => {
+    it('number', () => {
+      expect(Tree.from(42)).toMatchObject({
+        data: {
+          Type: MS.Number,
+        },
+      });
+    });
+    it('string', () => {
+      expect(Tree.from('hello world')).toMatchObject({
+        data: {
+          Type: MS.String,
+        },
+      });
+    });
+    it('boolean', () => {
+      expect(Tree.from(true)).toMatchObject({
+        data: {
+          Type: MS.Boolean,
+        },
+      });
+    });
+    it('array', () => {
+      expect(Tree.from(['a', 'b', 'c'])).toMatchObject({
+        data: {
+          Type: MS.Array,
+        },
+      });
+    });
+    describe('object', () => {
+      it('converts to type', () => {
+        expect(Tree.from({})).toMatchObject({
+          data: {
+            Type: expect.any(Function),
+          },
+        });
+      });
+      it('composes properties', () => {
+        expect(
+          Tree.from({
+            n: 10,
+            s: 'hello',
+            b: true,
+            a: ['a', 'b', 'c'],
+          })
+        ).toMatchObject({
+          data: {
+            Type: expect.any(Function),
+          },
+          children: {
+            n: {
+              data: {
+                Type: MS.Number,
+                path: ['n'],
+              },
+            },
+            s: {
+              data: {
+                Type: MS.String,
+                path: ['s'],
+              },
+            },
+            b: {
+              data: {
+                Type: MS.Boolean,
+                path: ['b'],
+              },
+            },
+            a: {
+              data: {
+                Type: MS.Array,
+                path: ['a'],
+              },
+            },
+          },
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
This PR makes it possible to use Microstates without defining type tree ahead of time. 

```js
import microstate from 'microstates';

microstate(42).increment().valueOf();
// 43

microstate({ items: ['a', 'b', 'c'] }).items.push('d').valueOf();
// { items: ['a', 'b', 'c', 'd'] }
```