### PR TITLE
Make static properties fully static

### DIFF
--- a/src/utils/constants-for.js
+++ b/src/utils/constants-for.js
@@ -1,28 +1,35 @@
 import { map, filter } from 'funcadelic';
 import getOwnPropertyDescriptors from 'object.getownpropertydescriptors';
+import { keep, reveal } from './secret';
 
 /**
- * Returns an object with constants from a type as getters. 
- * 
+ * Returns an object with constants from a type as getters.
+ *
  * For example,
- * 
+ *
  * ```js
  * constantsFor(class {
  *   isPending = true;
  *   isNew = false;
  * })
- * //=> { 
+ * //=> {
  * //  get isPending() { return true; }
  * //  get isNew() { return false; }
  * // }
  * ```
- * 
- * @param {*} Type 
+ *
+ * @param {*} Type
  */
 export default function constantsFor(Type) {
+  let instance = reveal(Type);
+  if (!instance) {
+    instance = new Type();
+    keep(Type, instance);
+  }
+
   let descriptors = filter(
     ({ value }) => typeof value.value !== 'function',
-    getOwnPropertyDescriptors(new Type())
+    getOwnPropertyDescriptors(instance)
   );
 
   return Object.create(

--- a/src/utils/secret.js
+++ b/src/utils/secret.js
@@ -1,4 +1,6 @@
-const symbol = Symbol('🙈 microstate');
+const symbol = Symbol('🙈');
+
+const { getOwnPropertySymbols } = Object;
 
 export function keep(object, value) {
   return Object.defineProperty(object, symbol, {
@@ -8,9 +10,7 @@ export function keep(object, value) {
 }
 
 export function reveal(object) {
-  if (object) {
+  if (object && getOwnPropertySymbols(object).includes(symbol)) {
     return object[symbol];
-  } else {
-    return object;
   }
 }

--- a/tests/microstate.test.js
+++ b/tests/microstate.test.js
@@ -540,17 +540,16 @@ describe('microstate', () => {
     });
   });
   describe('constants support', () => {
-    let ms = microstate(
-      class {
-        n = 10;
-        b = true;
-        s = 'hello';
-        o = { hello: 'world' };
-        a = ['a', 'b', 'c'];
-        null = null;
-        greeting = MS.String;
-      }
-    );
+    class Type {
+      n = 10;
+      b = true;
+      s = 'hello';
+      o = { hello: 'world' };
+      a = ['a', 'b', 'c'];
+      null = null;
+      greeting = MS.String;
+    }
+    let ms = microstate(Type);
     let next = ms.greeting.set('HI');
     it('includes constants in state tree', () => {
       // once transition-context is merged, need to add collapsed to
@@ -581,6 +580,9 @@ describe('microstate', () => {
     });
     it('next valueOf excludes constants', () => {
       expect(next.valueOf()).toEqual({ greeting: 'HI' });
+    });
+    it('shares complex objects between multiple instances of microstate', () => {
+      expect(ms.state.o).toBe(microstate(Type).state.o);
     });
   });
   describe('type-shifting', () => {

--- a/tests/utils/constants-for.test.js
+++ b/tests/utils/constants-for.test.js
@@ -31,4 +31,12 @@ describe('utils/constants-for', () => {
       a: ['a', 'b', 'c'],
     });
   });
+  it('shares constants for a Type', () => {
+    class MyType {
+      shared = {};
+    }
+    let a = constantsFor(MyType).shared;
+    let b = constantsFor(MyType).shared;
+    expect(a).toBe(b);
+  });
 });

--- a/tests/utils/secret.test.js
+++ b/tests/utils/secret.test.js
@@ -11,4 +11,17 @@ describe('utils/secret', () => {
     let obj = {};
     expect(reveal(keep(obj, 42))).toBe(42);
   });
+  describe('storing on Type', () => {
+    let Parent;
+    let Child;
+    beforeEach(() => {
+      Parent = class {};
+      Child = class extends Parent {};
+    });
+    it('does not share secret between child and parent', () => {
+      keep(Parent, 42);
+      expect(reveal(Parent)).toBe(42);
+      expect(reveal(Child)).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
This PR makes sure that once a type is instantiated, all following instances of that Type reference same static values as the first instance.

Closes #41 