### PR TITLE
Make it possible to type shift from a type constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,9 +371,17 @@ change the structure of a microstate you replace it with new microstate in a cus
 ```js
 class Session {
   content = null;
+
+  constructor(state) {
+    if (state) {
+      return new AuthenticatedSession(state);
+    } else {
+      return new AnonymousSession(state);
+    }
+  }
 }
 
-class AuthenticatedSession extends Session {
+class AuthenticatedSession {
   isAuthenticated = true;
   content = MS.Object;
 
@@ -382,7 +390,8 @@ class AuthenticatedSession extends Session {
   }
 }
 
-class AnonymousSession extends Session {
+class AnonymousSession {
+  content = null;
   isAuthenticated = false;
   authenticate(current, user) {
     return this(AuthenticatedSession, { content: user });
@@ -390,14 +399,24 @@ class AnonymousSession extends Session {
 }
 
 class MyApp {
-  session = AnonymousSession;
+  session = Session;
 }
 
+// without initial state it initializes into AnonymousSession state
 microstate(MyApp).state;
 // => { session: { content: null, isAuthenticated: false }}
 
+// transition to AuthenticatedSession state with authenticate
 microstate(MyApp).authenticate({ name: 'Taras' }).state;
 // => { session: { content: { name: 'Taras' }, isAuthenticated: true }};
+
+// restore into AuthenticatedSession state
+microstate(MyApp, { session: { content: { name: 'Taras' } } }).state;
+// => { session: { content: { name: 'Taras' } }, isAuthenticated: true }
+
+// transition to AnonymousSession state with logout
+microstate(MyApp, { session: { content: { name: 'Taras' } } }).logout().state;
+// => { session: { content: null, isAuthenticated: false }}
 ```
 
 # Built-in types
@@ -460,6 +479,7 @@ microstate(MS.Number).sum(5, 10).state;
 ### subtract(number: Number, [, number: Number]) => microstate
 
 Return a microstate with result of subtraction of passed in values from current state.
+<<<<<<< HEAD
 
 ```js
 microstate(MS.Number, 42).subtract(2, 10).state;
@@ -592,6 +612,9 @@ microstate(MS.Object).state;
 
 Replace state with value and return a new microstate with new state. The value will be coerced to
 object with `Object(value).valueOf()`.
+=======
+
+> > > > > > > Transitions are now generated for initialized state rather than original type
 
 ```js
 microstate(MS.Object).set({ hello: 'world' }).state;
@@ -650,4 +673,11 @@ class Employee extends Person {
     this.boss = Person;
   }
 }
+```
+
+## Run Tests
+
+```shell
+$ npm install
+$ npm test
 ```

--- a/src/utils/get-type.js
+++ b/src/utils/get-type.js
@@ -1,0 +1,27 @@
+import * as MS from '..';
+
+const { getPrototypeOf } = Object;
+
+/**
+ * Returns microstate type for a value.
+ */
+export default function getType(value) {
+  if (Array.isArray(value)) {
+    return MS.Array;
+  }
+  switch (typeof value) {
+    case 'number':
+      return MS.Number;
+    case 'string':
+      return MS.String;
+    case 'boolean':
+      return MS.Boolean;
+    case 'object':
+      let constructor = getPrototypeOf(value).constructor;
+      if (constructor === Object) {
+        return MS.Object;
+      } else {
+        return constructor;
+      }
+  }
+}

--- a/src/utils/to-type-class.js
+++ b/src/utils/to-type-class.js
@@ -1,0 +1,40 @@
+import { Monoid } from 'funcadelic';
+
+import * as MS from '..';
+import overload from './overload';
+import descriptorsFor from './descriptors-for';
+
+let Class = Monoid.create(
+  class {
+    empty() {
+      return class {};
+    }
+    append({ name, value }, Class) {
+      return overload(Class, name, toTypeClass(value));
+    }
+  }
+);
+
+export function toClass(value) {
+  return Class.reduce(descriptorsFor(value));
+}
+
+/**
+ * Converts a value into a type.
+ */
+export default function toTypeClass(value) {
+  if (Array.isArray(value)) {
+    return MS.Array;
+  }
+  switch (typeof value) {
+    case 'number':
+      return MS.Number;
+    case 'string':
+      return MS.String;
+    case 'boolean':
+      return MS.Boolean;
+    case 'object':
+      return toClass(value);
+  }
+  return value;
+}

--- a/src/utils/to-type-class.js
+++ b/src/utils/to-type-class.js
@@ -9,7 +9,7 @@ let Class = Monoid.create(
     empty() {
       return class {};
     }
-    append({ name, value }, Class) {
+    append(Class, { name, value }) {
       return overload(Class, name, toTypeClass(value));
     }
   }

--- a/src/utils/tree.js
+++ b/src/utils/tree.js
@@ -1,7 +1,5 @@
 import { append, filter, Functor, reduce, Monoid, map } from 'funcadelic';
-import * as MS from '..';
-import overload from './overload';
-import descriptorsFor from './descriptors-for';
+import toTypeClass from './to-type-class';
 
 let { keys } = Object;
 

--- a/src/utils/tree.js
+++ b/src/utils/tree.js
@@ -1,4 +1,4 @@
-import { append, filter, Functor, reduce, Monoid, map } from 'funcadelic';
+import { append, filter, Functor, reduce, map } from 'funcadelic';
 import toTypeClass from './to-type-class';
 
 let { keys } = Object;
@@ -80,28 +80,3 @@ Functor.instance(Tree, {
     });
   },
 });
-
-let Class = Monoid.create(
-  class {
-    empty() {
-      return class {};
-    }
-    append(Class, { name, value }) {
-      return overload(Class, name, toTypeClass(value));
-    }
-  }
-);
-
-function toTypeClass(Type) {
-  switch (typeof Type) {
-    case 'number':
-      return MS.Number;
-    case 'string':
-      return MS.String;
-    case 'boolean':
-      return MS.Boolean;
-    case 'object':
-      return Array.isArray(Type) ? MS.Array : Class.reduce(descriptorsFor(Type));
-  }
-  return Type;
-}


### PR DESCRIPTION
Previously transitions were built from Type ignoring the initialized state. This meant that state and transitions tree structure were mismatched. This PR generates transitions from Type of initialized state. 

I moved some code around to make them into their own functions.