### PR TITLE
Added Microstate Functor for mapping transitions

### DIFF
--- a/src/microstate.js
+++ b/src/microstate.js
@@ -1,5 +1,6 @@
 import state from './utils/state';
 import { keep, reveal } from './utils/secret';
+import { Functor, map } from 'funcadelic';
 
 const { assign } = Object;
 
@@ -42,3 +43,11 @@ export class Microstate {
     return reveal(this).value;
   }
 }
+
+Functor.instance(Microstate, {
+  map(fn, microstate) {
+    let { transitions } = reveal(microstate);
+    return map(transitions => map(transition => fn(transition), transitions), transitions)
+      .collapsed;
+  },
+});

--- a/tests/microstate.test.js
+++ b/tests/microstate.test.js
@@ -1,5 +1,5 @@
 import 'jest';
-
+import { map } from 'funcadelic';
 import microstate, * as MS from '../src';
 
 describe('microstate', () => {
@@ -789,6 +789,23 @@ describe('microstate', () => {
           },
         });
       });
+    });
+  });
+  describe('microstate transition mapping', function() {
+    class MyType {
+      myProp = MS.String;
+    }
+    let actions = map(transition => (...args) => transition(...args), microstate(MyType));
+    it('keeps objects as objects', () => {
+      expect(actions).toMatchObject({
+        set: expect.any(Function),
+        myProp: {
+          set: expect.any(Function),
+        },
+      });
+    });
+    it('has working transitions', () => {
+      expect(actions.myProp.set('foo').state).toEqual({ myProp: 'foo' });
     });
   });
 });


### PR DESCRIPTION
Microstate objects are nested transitions with a state property. Mapping microstate object is effectively mapping transitions. To map state one can do `map(v => v, ms.state)`. 

This PR adds Functor instance for Microstate class to allow mapping microstate transitions.