### PR TITLE
Upgrade to funcadelic 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@std/esm": "^0.14.0",
-    "funcadelic": "^0.2.6",
+    "funcadelic": "^0.3.0",
     "object.getownpropertydescriptors": "2.0.3",
     "ramda": "^0.25.0"
   },

--- a/src/utils/tree.js
+++ b/src/utils/tree.js
@@ -88,7 +88,7 @@ let Class = Monoid.create(
     empty() {
       return class {};
     }
-    append({ name, value }, Class) {
+    append(Class, { name, value }) {
       return overload(Class, name, toTypeClass(value));
     }
   }


### PR DESCRIPTION
The order of Mondoid reduction changed from `foldr` to `foldl` inside, but this broke all existing monoids because the arguments to `append` were passed in reverse order to what they were before.

This upgrades funcadelic and fixes the new argument order.

Makes #56 obsolete.