### PR TITLE
Setting up Functor instances from index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import './typeclasses';
 export { default } from './microstate';
 export { default as Number } from './types/number';
 export { default as String } from './types/string';

--- a/src/microstate.js
+++ b/src/microstate.js
@@ -1,6 +1,5 @@
 import state from './utils/state';
 import { keep, reveal } from './utils/secret';
-import { Functor, map } from 'funcadelic';
 
 const { assign } = Object;
 
@@ -43,11 +42,3 @@ export class Microstate {
     return reveal(this).value;
   }
 }
-
-Functor.instance(Microstate, {
-  map(fn, microstate) {
-    let { transitions } = reveal(microstate);
-    return map(transitions => map(transition => fn(transition), transitions), transitions)
-      .collapsed;
-  },
-});

--- a/src/typeclasses.js
+++ b/src/typeclasses.js
@@ -1,0 +1,32 @@
+import { Functor, map } from 'funcadelic';
+import { Microstate } from './microstate';
+import { reveal } from './utils/secret';
+import Tree from './utils/tree';
+
+Functor.instance(Microstate, {
+  map(fn, microstate) {
+    let { transitions } = reveal(microstate);
+    return map(transitions => map(transition => fn(transition), transitions), transitions)
+      .collapsed;
+  },
+});
+
+Functor.instance(Tree, {
+  /**
+   * Lazily invoke callback on every property of given tree,
+   * the return value is assigned to property value.
+   *
+   * @param {*} fn (TypeTree, path) => any
+   * @param {*} tree Tree
+   */
+  map(fn, tree) {
+    return new Tree({
+      data() {
+        return fn(tree.data);
+      },
+      children() {
+        return map(child => map(fn, child), tree.children);
+      },
+    });
+  },
+});

--- a/src/utils/tree.js
+++ b/src/utils/tree.js
@@ -1,4 +1,4 @@
-import { append, filter, Functor, reduce, map } from 'funcadelic';
+import { append, filter, reduce, map } from 'funcadelic';
 import toTypeClass from './to-type-class';
 
 let { keys } = Object;
@@ -60,23 +60,3 @@ export default class Tree {
     });
   }
 }
-
-Functor.instance(Tree, {
-  /**
-   * Lazily invoke callback on every property of given tree,
-   * the return value is assigned to property value.
-   *
-   * @param {*} fn (TypeTree, path) => any
-   * @param {*} tree Tree
-   */
-  map(fn, tree) {
-    return new Tree({
-      data() {
-        return fn(tree.data);
-      },
-      children() {
-        return map(child => map(fn, child), tree.children);
-      },
-    });
-  },
-});


### PR DESCRIPTION
For Functor map to work correctly Functor.instance needs to be setup before `map` is used anywhere. This PR moves typeclasses setup to index.js module to ensure that instances are setup before anything from microstate library can be used. 