### PR TITLE
Introduce chaining API.

### DIFF
--- a/src/utils/chain.js
+++ b/src/utils/chain.js
@@ -1,0 +1,25 @@
+import { map, filter, append } from 'funcadelic';
+
+class Chain {
+  constructor(value) {
+    Object.defineProperty(this, 'valueOf', {
+      value() {
+        return value;
+      },
+    });
+  }
+  map(fn) {
+    return new Chain(map(fn, this.valueOf()));
+  }
+  filter(fn) {
+    return new Chain(filter(fn, this.valueOf()));
+  }
+
+  append(thing) {
+    return new Chain(append(this.valueOf(), thing));
+  }
+}
+
+export default function chain(value) {
+  return new Chain(value);
+}

--- a/src/utils/constants-for.js
+++ b/src/utils/constants-for.js
@@ -1,4 +1,4 @@
-import { map, filter } from 'funcadelic';
+import $ from './chain';
 import getOwnPropertyDescriptors from 'object.getownpropertydescriptors';
 import { keep, reveal } from './secret';
 
@@ -27,21 +27,15 @@ export default function constantsFor(Type) {
     keep(Type, instance);
   }
 
-  let descriptors = filter(
-    ({ value }) => typeof value.value !== 'function',
-    getOwnPropertyDescriptors(instance)
-  );
+  let properties = $(getOwnPropertyDescriptors(instance))
+    .filter(({ value }) => typeof value.value !== 'function')
+    .map(descriptor => ({
+      get() {
+        return descriptor.value;
+      },
+      enumerable: true,
+    }))
+    .valueOf();
 
-  return Object.create(
-    Type.prototype,
-    map(
-      descriptor => ({
-        get() {
-          return descriptor.value;
-        },
-        enumerable: true,
-      }),
-      descriptors
-    )
-  );
+  return Object.create(Type.prototype, properties);
 }

--- a/src/utils/getters-for.js
+++ b/src/utils/getters-for.js
@@ -1,11 +1,12 @@
+import $ from './chain';
 import { append, filter, map } from 'funcadelic';
 import getOwnPropertyDescriptors from 'object.getownpropertydescriptors';
 
 export default function gettersFor(Type) {
-  let descriptors = filter(({ value }) => !!value.get, getOwnPropertyDescriptors(Type.prototype));
+  let descriptors = $(getOwnPropertyDescriptors(Type.prototype))
+    .filter(({ value }) => !!value.get)
+    .map(descriptor => append(descriptor, { enumerable: true }))
+    .valueOf();
 
-  return Object.create(
-    Type.prototype,
-    map(descriptor => append(descriptor, { enumerable: true }), descriptors)
-  );
+  return Object.create(Type.prototype, descriptors);
 }

--- a/src/utils/transitions-for.js
+++ b/src/utils/transitions-for.js
@@ -1,4 +1,5 @@
-import { append, filter, map } from 'funcadelic';
+import $ from './chain';
+import { append } from 'funcadelic';
 import mergeDeepRight from 'ramda/src/mergeDeepRight';
 import getPrototypeDescriptors from './get-prototype-descriptors';
 
@@ -14,12 +15,12 @@ const merge = function merge(current, ...args) {
 
 export default function transitionsFor(Type) {
   let descriptors = getPrototypeDescriptors(Type);
-  let methods = filter(({ value }) => isFunctionDescriptor(value), descriptors);
 
-  let transitionFns = filter(
-    ({ key }) => key !== 'constructor',
-    map(({ value }) => value, methods)
-  );
+  let transitionFns = $(descriptors)
+    .filter(({ value }) => isFunctionDescriptor(value))
+    .map(({ value }) => value)
+    .filter(({ key }) => key !== 'constructor')
+    .valueOf();
 
   let common = isPrimitive(Type) ? { set } : { set, merge };
   return append(common, transitionFns);

--- a/src/utils/tree.js
+++ b/src/utils/tree.js
@@ -1,3 +1,4 @@
+import $ from './chain';
 import { append, filter, reduce, map } from 'funcadelic';
 import toTypeClass from './to-type-class';
 
@@ -53,9 +54,10 @@ export default class Tree {
        * Eager evaluation would cause infinite loop because parent would be evaluated recursively.
        */
       children() {
-        let childTypes = filter(({ value }) => !!value && value.call, new Type());
-
-        return map((ChildType, key) => Tree.from(ChildType, append(path, key)), childTypes);
+        return $(new Type())
+          .filter(({ value }) => !!value && value.call)
+          .map((ChildType, key) => Tree.from(ChildType, append(path, key)))
+          .valueOf();
       },
     });
   }


### PR DESCRIPTION
The funcadelic function signatures for `map`, `filter`, and `foldl` don't read well in JavaScript when you start composing them a lot in a single place.

The filter -> map -> filter operation that's happening here in this pipeline isn't really captured by the way the code reads.

```js
let methods = filter(({ value }) => isFunctionDescriptor(value), descriptors);
let transitionFns = filter(
  ({ key }) => key !== 'constructor',
  map(({ value }) => value, methods)
);
```

The flow of data is.

1. filter out everything that isn't a function descriptor
2. map the descriptor to the actual function
3. filter out the 'constructor' function

To follow this flow in the code though, you have to start on line 1, but then jump to line 4, then jump back up to line 2.

When you're reading the code for the first time (or a second, or a third), it makes an already difficult task that much harder. We're doing some amazingly complex and subtle transformations to these structures, so the least we can do is highlight the steps involved.

This introduces a chaining API so that code flow can follow transform flow. By making the transform (chain) itself a first class entity, we can track it directly. So for example, the above code becomes:

```js
let transitionFns = $(descriptors)
  .filter(({ value }) => isFunctionDescriptor(value))
  .map(({ value }) => value)
  .filter(({ key }) => key !== 'constructor')
  .valueOf();
```

And the flow of the transform (filter -> map -> filter) becomes illuminated by the code instead of obscured by it.

As a nice knock-on effect, it also addresses the problem of forgetting the "subject" of a `map` or a `filter`. When you're mapping, you're usually so focused on the transform itself that you often forget to include what you're mapping over, which results in weird runtime errors.

With the chaining API, you "capture" your subject at the very beginning, and you hold onto it with each transformation, so it never gets lost.