### PR TITLE
Defunk the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,42 +22,35 @@ npm install --save microstates
 
 # yarn add microstates
 ```
-
-`microstates` module exports a microstate constructor as `default` and built in types: `Number`,
-`String`, `Boolean`, `Object` and `Array`.
-
-_Note_: We recommend `import * as MS from 'microstates'` syntax, to hide built-in types behind a
-namespace. Otherwise they'll overwrite built in JavaScript classes in the module.
-
 Let's see some code,
 
 ```js
-import microstate, * as MS from 'microstates';
+import Microstate from 'microstates';
 
-microstate(MS.Number, 42).increment().state;
+Microstate.create(Number, 42).increment().state;
 //=> 43
 
 class MyCounter {
-  count = MS.Number;
+  count = Number;
 }
 
 // creating microstate from composed states
-microstate(MyCounter).state;
+Microstate.create(MyCounter).state;
 // => { count: 0 }
 
-microstate(MyCounter).count.increment().state;
+Microstate.create(MyCounter).count.increment().state;
 // => { count: 1 }
 
 class MyModal {
-  isOpen = MS.Boolean;
-  title = MS.String;
+  isOpen = Boolean;
+  title = String;
 }
 
 // you can restore a microstate from previous value
-microstate(MyModal, { isOpen: true, title: 'Hello World' }).state;
+Microstate.create(MyModal, { isOpen: true, title: 'Hello World' }).state;
 // => { isOpen: true, title: 'Hello World' }
 
-microstate(MyModal, { isOpen: true, title: 'Hello World' }).isOpen.toggle().state;
+Microstate.create(MyModal, { isOpen: true, title: 'Hello World' }).isOpen.toggle().state;
 // => { isOpen: false, title: 'Hello World' }
 
 // lets composed multiple state together
@@ -66,13 +59,13 @@ class MyState {
   counter = MyCounter;
 }
 
-microstate(MyState).state;
+Microstate.create(MyState).state;
 // => {
 //  modal: { isOpen: false, title: '' },
 //  counter: { count: 0 }
 // }
 
-microstate(MyState)
+Microstate.create(MyState)
   .counter.increment()
   .modal.title.set('Hello World')
   .modal.isOpen.set(true).state;
@@ -89,18 +82,18 @@ the structure of your state and `value` that is the initial state.
 
 ```js
 // initial value is undefined so state will be default value of String which is an empty string
-microstate(MS.String).state;
+Microstate.create(String).state;
 // => ''
 
 // initial value is 'hello world' so state will be hello world.
-microstate(MS.String, 'hello world').state;
+Microstate.create(String, 'hello world').state;
 // => 'hello world'
 ```
 
 The object returned from the constructor has all of the transitions for the structure.
 
 ```js
-let ms = microstate(MS.Object);
+let ms = Microstate.create(Object);
 
 console.log(ms);
 //  {
@@ -108,7 +101,7 @@ console.log(ms);
 //    set: Function
 //  }
 
-ms.assign({ hello: 'world', hi: 'there' }).state;
+assign({ hello: 'world', hi: 'there' }).state;
 // => { hello: 'world', hi: 'there' }
 ```
 
@@ -123,10 +116,10 @@ any function can work as a type, but we recommend using class syntax.
 
 ```js
 class Counter {
-  count = MS.Number;
+  count = Number;
 }
 
-microstate(Counter);
+Microstate.create(Counter);
 // => {
 //      merge: Function
 //      set: Function
@@ -138,7 +131,7 @@ microstate(Counter);
 //      }
 //    }
 
-microstate(Counter).state;
+Microstate.create(Counter).state;
 // => { count: 0 }
 ```
 
@@ -148,21 +141,21 @@ Properties to work.
 
 ```js
 class Person {
-  name = MS.String;
-  age = MS.Number;
+  name = String;
+  age = Number;
 }
 
-microstate(Person);
+Microstate.create(Person);
 // => {
 //      name: { concat: Function, set: Function },
 //      age: { increment: Function, decrement: Function, sum: Function, subtract: Function }
 //    }
 
 // state objects maintain their type's class
-microstate(Person).state instanceof Person;
+Microstate.create(Person).state instanceof Person;
 // => true
 
-microstate(Person).state;
+Microstate.create(Person).state;
 // => { name: '', age: 0 }
 ```
 
@@ -170,7 +163,7 @@ You can restore a composed microstate by providing initial value that matches th
 microstate.
 
 ```js
-microstate(Person, { name: 'Taras', age: 99 }).state;
+Microstate.create(Person, { name: 'Taras', age: 99 }).state;
 // => { name: 'Taras', age: 99 }
 ```
 
@@ -178,18 +171,18 @@ You can compose custom types into other custom types.
 
 ```js
 class Address {
-  street = MS.String;
-  number = MS.Number;
-  city = MS.String;
+  street = String;
+  number = Number;
+  city = String;
 }
 
 class Person {
-  name = MS.String;
-  age = MS.Number;
+  name = String;
+  age = Number;
   address = Address;
 }
 
-microstate(Person, { name: 'Taras', address: { city: 'Toronto' } }).state;
+Microstate.create(Person, { name: 'Taras', address: { city: 'Toronto' } }).state;
 // => {
 //      name: 'Taras',
 //      age: 0,
@@ -205,7 +198,7 @@ You can access transitions of composed states by using object property notation.
 call a transition, you receive a new microstate and you start from the root of the original type.
 
 ```js
-microstate(Person)
+Microstate.create(Person)
   .age.increment()
   .address.city.set('San Francisco')
   .address.street.set('Market St').state;
@@ -224,7 +217,7 @@ The objects can be of any complexity and can even support recursion.
 
 ```js
 class Person {
-  name = MS.String;
+  name = String;
   father = Person;
 }
 
@@ -253,14 +246,14 @@ Composed states have two default transitions `set` and `merge`.
 `set` will replace the state of current microstate.
 
 ```js
-microstate(Person).father.father.set({ name: 'Peter' }).state;
+Microstate.create(Person).father.father.set({ name: 'Peter' }).state;
 // => { name: '', father: { name: 'Peter' }}
 ```
 
 `merge` will recursively merge the object into current state.
 
 ```js
-microstate(Person, { name: 'Peter' }).merge({ name: 'Taras', father: { name: 'Serge' } }).state;
+Microstate.create(Person, { name: 'Peter' }).merge({ name: 'Taras', father: { name: 'Serge' } }).state;
 // { name: 'Taras', father: { name: 'Serge' }}
 ```
 
@@ -275,16 +268,16 @@ class Ajax {
   isLoaded = false;
 }
 
-microstate(Ajax).state.content;
+Microstate.create(Ajax).state.content;
 // => null;
 
-microstate(Ajax).content;
+Microstate.create(Ajax).content;
 // undefined
 
-microstate(Ajax).state.isLoaded;
+Microstate.create(Ajax).state.isLoaded;
 // => false
 
-microstate(Ajax).isLoaded.set(false);
+Microstate.create(Ajax).isLoaded.set(false);
 // Error: calling set of undefined
 ```
 
@@ -296,16 +289,16 @@ states.
 
 ```js
 class Measure {
-  length = MS.Number;
+  length = Number;
   get inInches() {
     return `${this.height / 2.54} inches`;
   }
 }
 
-microstate(Measure, { length: 170 }).state.inInches;
+Microstate.create(Measure, { length: 170 }).state.inInches;
 // => '66.9291 inches'
 
-microstate(Measure, { length: 170 }).height.set(160).state.inInches;
+Microstate.create(Measure, { length: 170 }).height.set(160).state.inInches;
 // => '62.9921 inches'
 ```
 
@@ -316,8 +309,8 @@ current state and transition local state.
 
 ```js
 class Person {
-  home: MS.String;
-  location: MS.String;
+  home: String;
+  location: String;
   goHome(current) {
     if (current.home !== current.location) {
       return this.location.set(current.home);
@@ -327,7 +320,7 @@ class Person {
   }
 }
 
-microstate(Person, { home: 'Toronto', location: 'San Francisco' }).goHome().state;
+Microstate.create(Person, { home: 'Toronto', location: 'San Francisco' }).goHome().state;
 // => { home: 'Toronto', location: 'Toronto' }
 ```
 
@@ -339,9 +332,9 @@ microstate. All of the operations we'll execute before the transformation is com
 
 ```js
 class MyModal {
-  isOpen = MS.Boolean;
-  title = MS.String;
-  content = MS.String;
+  isOpen = Boolean;
+  title = String;
+  content = String;
 
   show(current, title, content) {
     return this
@@ -353,10 +346,10 @@ class MyModal {
 
 class MyComponent {
   modal = MyModal;
-  counter = MS.Number
+  counter = Number
 }
 
-microstate(MyComponent).modal.show('Hello World', 'Rise and shine!').state;
+Microstate.create(MyComponent).modal.show('Hello World', 'Rise and shine!').state;
 // => { modal: { isOpen: true, title: 'Hello World', content: 'Rise and shine!' }, counter: 0 }
 ```
 
@@ -381,7 +374,7 @@ class Session {
 
 class AuthenticatedSession {
   isAuthenticated = true;
-  content = MS.Object;
+  content = Object;
 
   logout() {
     return this.set(AnonymousSession);
@@ -401,19 +394,19 @@ class MyApp {
 }
 
 // without initial state it initializes into AnonymousSession state
-microstate(MyApp).state;
+Microstate.create(MyApp).state;
 // => { session: { content: null, isAuthenticated: false }}
 
 // transition to AuthenticatedSession state with authenticate
-microstate(MyApp).authenticate({ name: 'Taras' }).state;
+Microstate.create(MyApp).authenticate({ name: 'Taras' }).state;
 // => { session: { content: { name: 'Taras' }, isAuthenticated: true }};
 
 // restore into AuthenticatedSession state
-microstate(MyApp, { session: { content: { name: 'Taras' } } }).state;
+Microstate.create(MyApp, { session: { content: { name: 'Taras' } } }).state;
 // => { session: { content: { name: 'Taras' } }, isAuthenticated: true }
 
 // transition to AnonymousSession state with logout
-microstate(MyApp, { session: { content: { name: 'Taras' } } }).logout().state;
+Microstate.create(MyApp, { session: { content: { name: 'Taras' } } }).logout().state;
 // => { session: { content: null, isAuthenticated: false }}
 ```
 
@@ -432,7 +425,7 @@ Return a new microstate with boolean value replaced. Value will be coerced with
 `Boolean(value).valueOf()`.
 
 ```js
-microstate(MS.Boolean).set(true).state;
+Microstate.create(Boolean).set(true).state;
 // => true
 ```
 
@@ -441,13 +434,13 @@ microstate(MS.Boolean).set(true).state;
 Return a new microstate with state of boolean value switched to opposite.
 
 ```js
-microstate(MS.Boolean).state;
+Microstate.create(Boolean).state;
 // => false
 
-microstate(MS.Boolean).toggle().state;
+Microstate.create(Boolean).toggle().state;
 // => true;
 
-microstate(MS.Boolean, true).toggle().state;
+Microstate.create(Boolean, true).toggle().state;
 // => false;
 ```
 
@@ -461,7 +454,7 @@ microstate(MS.Boolean, true).toggle().state;
 Replace current state with value. The value will be coerced same as `Number(value).valueOf()`.
 
 ```js
-microstate(MS.Number).set(10).state;
+Microstate.create(Number).set(10).state;
 // => 10
 ```
 
@@ -470,7 +463,7 @@ microstate(MS.Number).set(10).state;
 Return a microstate with result of adding passed in values to current state.
 
 ```js
-microstate(MS.Number).sum(5, 10).state;
+Microstate.create(Number).sum(5, 10).state;
 // => 15
 ```
 
@@ -480,7 +473,7 @@ Return a microstate with result of subtraction of passed in values from current 
 <<<<<<< HEAD
 
 ```js
-microstate(MS.Number, 42).subtract(2, 10).state;
+Microstate.create(Number, 42).subtract(2, 10).state;
 // => 30
 ```
 
@@ -489,13 +482,13 @@ microstate(MS.Number, 42).subtract(2, 10).state;
 Return a microstate with state increased by step value of current state (defaults to 1).
 
 ```js
-microstate(MS.Number).increment().state;
+Microstate.create(Number).increment().state;
 // => 1
 
-microstate(MS.Number).increment(5).state;
+Microstate.create(Number).increment(5).state;
 // => 5
 
-microstate(MS.Number)
+Microstate.create(Number)
   .increment(5)
   .increment().state;
 // => 6
@@ -506,13 +499,13 @@ microstate(MS.Number)
 Return a microstate with state decreased by step value of current state (defaults to 1).
 
 ```js
-microstate(MS.Number).decrement().state;
+Microstate.create(Number).decrement().state;
 // => -1
 
-microstate(MS.Number).decrement(5).state;
+Microstate.create(Number).decrement(5).state;
 // => -5
 
-microstate(MS.Number)
+Microstate.create(Number)
   .decrement(5)
   .decrement().state;
 // => -6
@@ -529,7 +522,7 @@ Replace the state with value and return a new microsate with new state. Value wi
 `String(value).valueOf()`.
 
 ```js
-microstate(MS.String).set('hello world').state;
+Microstate.create(String).set('hello world').state;
 // => 'hello world'
 ```
 
@@ -538,13 +531,13 @@ microstate(MS.String).set('hello world').state;
 Combine current state with passed in string and return a new microstate with new state.
 
 ```js
-microstate(MS.String, 'hello ').concat('world').state;
+Microstate.create(String, 'hello ').concat('world').state;
 // => 'hello world'
 ```
 
 ## Array
 
-Represents an indexed collection of items.
+Represents an indexed collection of ite
 
 ### set(value: any) => microstate
 
@@ -552,7 +545,7 @@ Replace state with value and return a new microstate with new state. Value will 
 `Array(value).valueOf()`
 
 ```js
-microstate(MS.Array).set('hello world');
+Microstate.create(Array).set('hello world');
 // ['hello world']
 ```
 
@@ -561,10 +554,10 @@ microstate(MS.Array).set('hello world');
 Push value to the end of the array and return a new microstate with state as new array.
 
 ```js
-microstate(MS.Array).push(10, 15, 25).state;
+Microstate.create(Array).push(10, 15, 25).state;
 // => [ 10, 15, 25 ]
 
-microstate(MS.Array, ['a', 'b'])
+Microstate.create(Array, ['a', 'b'])
   .push('c')
   .push('d').state;
 // => [ 'a', 'b', 'c', 'd' ]
@@ -575,7 +568,7 @@ microstate(MS.Array, ['a', 'b'])
 Apply filter fn to every element in the array and return a new microstate with result as state.
 
 ```js
-microstate(MS.Array, [10.123, 1, 42, 0.01]).filter(value => Number.isNumber(value)).state;
+Microstate.create(Array, [10.123, 1, 42, 0.01]).filter(value => Number.isNumber(value)).state;
 // => [ 1, 42 ];
 ```
 
@@ -584,7 +577,7 @@ microstate(MS.Array, [10.123, 1, 42, 0.01]).filter(value => Number.isNumber(valu
 Map every item in array and return a new microstate with new array as state.
 
 ```js
-microstate(MS.Array, ['a', 'b', 'c']).map(v => v.toUpperCase()).state;
+Microstate.create(Array, ['a', 'b', 'c']).map(v => v.toUpperCase()).state;
 // => ['A', 'B', 'C']
 ```
 
@@ -593,7 +586,7 @@ microstate(MS.Array, ['a', 'b', 'c']).map(v => v.toUpperCase()).state;
 Replace first occurance of `item` in array with `replacement` using exact(`===`) comparison.
 
 ```js
-microstate(MS.Array, ['a', 'b', 'c']).replace('b', 'B').state;
+Microstate.create(Array, ['a', 'b', 'c']).replace('b', 'B').state;
 // => [ 'a', 'B', 'c' ]
 ```
 
@@ -602,7 +595,7 @@ microstate(MS.Array, ['a', 'b', 'c']).replace('b', 'B').state;
 Represents a collection of values keyed by string. Object types have `assign` and `set` transitions.
 
 ```js
-microstate(MS.Object).state;
+Microstate.create(Object).state;
 // => {}
 ```
 
@@ -612,7 +605,7 @@ Replace state with value and return a new microstate with new state. The value w
 object with `Object(value).valueOf()`.
 
 ```js
-microstate(MS.Object).set({ hello: 'world' }).state;
+Microstate.create(Object).set({ hello: 'world' }).state;
 // => { hello: 'world' }
 ```
 
@@ -622,7 +615,7 @@ Create a new object and copy values from existing state and passed in object. Re
 microstate with new state.
 
 ```js
-microstate(MS.Object, { color: 'red' }).assign({ make: 'Honda' }).state;
+Microstate.create(Object, { color: 'red' }).assign({ make: 'Honda' }).state;
 // => { color: 'red', make: 'Honda' }
 ```
 
@@ -635,8 +628,8 @@ things as you would with classes.
 
 ```js
 class Person {
-  name = MS.String;
-  age = MS.Number;
+  name = String;
+  age = Number;
 }
 ```
 
@@ -644,8 +637,8 @@ class Person {
 
 ```js
 function Person() {
-  this.name = MS.String;
-  this.age = MS.Number;
+  this.name = String;
+  this.age = Number;
 }
 ```
 
@@ -657,8 +650,8 @@ can try the following.
 ```js
 class Person {
   constructor() {
-    this.name = MS.String;
-    this.age = MS.Number;
+    this.name = String;
+    this.age = Number;
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -309,12 +309,10 @@ microstate(Measure, { length: 170 }).height.set(160).state.inInches;
 // => '62.9921 inches'
 ```
 
-# Custom Transitions
+# Transitions
 
-You can define custom transitions on custom types. Inside of custom transitions, you have access to
-current state and ability to transition local state using `this()` function. You probably never seen
-`this()` before. Think about it as a function that returns a microstate for the current node. It is
-actually a microstate constructor that is bound to custom transitions.
+You can define transitions on custom types. Inside of transitions, you have access to
+current state and transition local state.
 
 ```js
 class Person {
@@ -322,7 +320,7 @@ class Person {
   location: MS.String;
   goHome(current) {
     if (current.home !== current.location) {
-      return this().location.set(current.home);
+      return this.location.set(current.home);
     } else {
       return current;
     }
@@ -335,7 +333,7 @@ microstate(Person, { home: 'Toronto', location: 'San Francisco' }).goHome().stat
 
 # Batch Transitions
 
-Custom transitions can be used to perform multiple transformations in sequence. This is useful when
+Transitions can be used to perform multiple transformations in sequence. This is useful when
 you have a deeply nested microstate and you're applying several transformations to one branch of the
 microstate. All of the operations we'll execute before the transformation is complete.
 
@@ -346,7 +344,7 @@ class MyModal {
   content = MS.String;
 
   show(current, title, content) {
-    return this()
+    return this
       .isOpen.set(true),
       .title.set(title)
       .content.set(content)
@@ -386,7 +384,7 @@ class AuthenticatedSession {
   content = MS.Object;
 
   logout() {
-    return this(AnonymousSession);
+    return this.set(AnonymousSession);
   }
 }
 
@@ -394,7 +392,7 @@ class AnonymousSession {
   content = null;
   isAuthenticated = false;
   authenticate(current, user) {
-    return this(AuthenticatedSession, { content: user });
+    return this.set(AuthenticatedSession, { content: user });
   }
 }
 
@@ -612,9 +610,6 @@ microstate(MS.Object).state;
 
 Replace state with value and return a new microstate with new state. The value will be coerced to
 object with `Object(value).valueOf()`.
-=======
-
-> > > > > > > Transitions are now generated for initialized state rather than original type
 
 ```js
 microstate(MS.Object).set({ hello: 'world' }).state;

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ console.log(ms);
 //    set: Function
 //  }
 
-assign({ hello: 'world', hi: 'there' }).state;
+ms.assign({ hello: 'world', hi: 'there' }).state;
 // => { hello: 'world', hi: 'there' }
 ```
 
@@ -311,11 +311,12 @@ current state and transition local state.
 class Person {
   home: String;
   location: String;
-  goHome(current) {
-    if (current.home !== current.location) {
-      return this.location.set(current.home);
+  goHome() {
+    let { home, location } = this.state;
+    if (home !== location) {
+      return this.location.set(home);
     } else {
-      return current;
+      return this.state;
     }
   }
 }
@@ -336,7 +337,7 @@ class MyModal {
   title = String;
   content = String;
 
-  show(current, title, content) {
+  show(title, content) {
     return this
       .isOpen.set(true),
       .title.set(title)
@@ -384,7 +385,7 @@ class AuthenticatedSession {
 class AnonymousSession {
   content = null;
   isAuthenticated = false;
-  authenticate(current, user) {
+  authenticate(user) {
     return this.set(AuthenticatedSession, { content: user });
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "jsonfile": "^4.0.0",
     "lint-staged": "6.0.0",
     "prettier": "^1.10.2",
+    "pretty-format": "22.1.0",
     "rollup": "^0.53.0",
     "rollup-plugin-babel": "^4.0.0-beta.0",
     "standard-version": "^4.2.0"

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,8 @@
 import './typeclasses';
-export { default } from './microstate';
+import Microstate from './microstate';
+
+export default Microstate;
+export const create = Microstate.create;
 
 export { default as Tree } from './utils/tree';
 export { default as analyze } from './structure';

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,5 @@
 import './typeclasses';
 export { default } from './microstate';
-export { default as Number } from './types/number';
-export { default as String } from './types/string';
-export { default as Boolean } from './types/boolean';
-export { default as Array } from './types/array';
-export { default as Object } from './types/object';
 
 export { default as Tree } from './utils/tree';
 export { default as analyze } from './structure';

--- a/src/microstate.js
+++ b/src/microstate.js
@@ -70,9 +70,7 @@ function state(value, tree) {
 }
 
 function invoke({ method, args, value, tree}) {
-
-  let nextValue = method.apply(new Microstate(tree, value), [state(value, tree), ...args]);
-
+  let nextValue = method.apply(new Microstate(tree, value), args);
   if (nextValue instanceof Microstate) {
     return reveal(nextValue);
   } else {

--- a/src/microstate.js
+++ b/src/microstate.js
@@ -4,23 +4,23 @@ import { keep, reveal } from './utils/secret';
 
 const { assign } = Object;
 
-/**
- * Returns a new Microstate instance. A microstate is an object that
- * wraps a type and a value and provides chainable transitions for
- * this value.
- *
- * @param {*} Type
- * @param {*} value
- */
-export default function create(Type, value) {
-  let tree = analyze(Type, value);
-  return new Microstate(tree, value);
-}
-
-export class Microstate {
+export default class Microstate {
   constructor(tree, value) {
     keep(this, { tree, value });
     return assign(this, transitions(value, tree));
+  }
+
+  /**
+   * Returns a new Microstate instance. A microstate is an object that
+   * wraps a type and a value and provides chainable transitions for
+   * this value.
+   *
+   * @param {*} Type
+   * @param {*} value
+   */
+  static create(Type, value) {
+    let tree = analyze(Type, value);
+    return new Microstate(tree, value);
   }
 
   /**

--- a/src/microstate.js
+++ b/src/microstate.js
@@ -4,6 +4,36 @@ import { keep, reveal } from './utils/secret';
 
 const { assign } = Object;
 
+export class Microstate {
+  constructor(tree, value) {
+    keep(this, { tree, value });
+    return assign(this, transitions(value, tree));
+  }
+
+  /**
+   * Evaluates to state for this microstate.
+   */
+  get state() {
+    let { tree, value } = reveal(this);
+    return state(value, tree);
+  }
+
+  set state(value) {
+    let message = typeof value === 'function'
+      ? `You can not use 'state' as transition name because it'll conflict with state property on the microstate.`
+      : `Setting state property will not do anything useful. Please don't do this.`;
+    throw new Error(message);
+  }
+
+  /**
+   * Return boxed in value for this microstates
+   */
+  valueOf() {
+    let { value } = reveal(this);
+    return value;
+  }
+}
+
 /**
  * Returns a new Microstate instance. A microstate is an object that
  * wraps a type and a value and provides chainable transitions for
@@ -33,18 +63,6 @@ function transitions(value, tree) {
   }, tree);
 }
 
-function context(tree, value) {
-  return function transitionContext(nextType, nextValue = value) {
-    // context is invoked with arguments
-    if (nextType) {
-      return create(nextType, nextValue);
-    } else {
-      let ms = new Microstate(tree, value);
-      return ms;
-    }
-  }
-}
-
 function state(value, tree) {
   return collapse(node => {
     return node.stateAt(value);
@@ -53,42 +71,11 @@ function state(value, tree) {
 
 function invoke({ method, args, value, tree}) {
 
-  let transitionContext = context(tree, value);
-  let nextValue = method.apply(transitionContext, [state(value, tree), ...args]);
+  let nextValue = method.apply(new Microstate(tree, value), [state(value, tree), ...args]);
 
   if (nextValue instanceof Microstate) {
     return reveal(nextValue);
   } else {
     return { tree, value: nextValue };
-  }
-}
-
-export class Microstate {
-  constructor(tree, value) {
-    keep(this, { tree, value });
-    return assign(this, transitions(value, tree));
-  }
-
-  /**
-   * Evaluates to state for this microstate.
-   */
-  get state() {
-    let { tree, value } = reveal(this);
-    return state(value, tree);
-  }
-
-  set state(value) {
-    let message = typeof value === 'function'
-      ? `You can not use 'state' as transition name because it'll conflict with state property on the microstate.`
-      : `Setting state property will not do anything useful. Please don't do this.`;
-    throw Error(message);
-  }
-
-  /**
-   * Return boxed in value for this microstates
-   */
-  valueOf() {
-    let { value } = reveal(this);
-    return value;
   }
 }

--- a/src/microstate.js
+++ b/src/microstate.js
@@ -4,6 +4,19 @@ import { keep, reveal } from './utils/secret';
 
 const { assign } = Object;
 
+/**
+ * Returns a new Microstate instance. A microstate is an object that
+ * wraps a type and a value and provides chainable transitions for
+ * this value.
+ *
+ * @param {*} Type
+ * @param {*} value
+ */
+export default function create(Type, value) {
+  let tree = analyze(Type, value);
+  return new Microstate(tree, value);
+}
+
 export class Microstate {
   constructor(tree, value) {
     keep(this, { tree, value });
@@ -32,19 +45,6 @@ export class Microstate {
     let { value } = reveal(this);
     return value;
   }
-}
-
-/**
- * Returns a new Microstate instance. A microstate is an object that
- * wraps a type and a value and provides chainable transitions for
- * this value.
- *
- * @param {*} Type
- * @param {*} value
- */
-export default function create(Type, value) {
-  let tree = analyze(Type, value);
-  return new Microstate(tree, value);
 }
 
 function collapse(fn, tree) {

--- a/src/structure.js
+++ b/src/structure.js
@@ -19,12 +19,13 @@ export default function analyze(Type, value) {
 }
 
 function analyzeType(Type, path = []) {
+  let type = getType(Type);
   return new Tree({
     data() {
-      return new Node(Type, path);
+      return new Node(type, path);
     },
     children() {
-      return $(new Type())
+      return $(new type())
         .filter(({ value }) => !!value && value.call)
         .map((ChildType, key) => analyzeType(ChildType, append(path, key)))
         .valueOf();

--- a/src/structure.js
+++ b/src/structure.js
@@ -1,7 +1,6 @@
 import $ from './utils/chain';
 import { map, append } from 'funcadelic';
 import { view, set, lensTree, lensPath, lensIndex } from './lens';
-import equals from './utils/equals';
 import Tree from './utils/tree';
 import isPrimitive from './utils/is-primitive';
 import transitionsFor from './utils/transitions-for';

--- a/src/typeclasses.js
+++ b/src/typeclasses.js
@@ -1,9 +1,9 @@
 import { Applicative, Functor, map } from 'funcadelic';
 import { Monad, flatMap } from './monad';
-import thunk from './thunk';
 import { Microstate } from './microstate';
 import { reveal } from './utils/secret';
 import Tree from './utils/tree';
+import thunk from './thunk';
 
 Functor.instance(Microstate, {
   map(fn, microstate) {

--- a/src/typeclasses.js
+++ b/src/typeclasses.js
@@ -1,6 +1,6 @@
 import { Applicative, Functor, map } from 'funcadelic';
 import { Monad, flatMap } from './monad';
-import { Microstate } from './microstate';
+import Microstate from './microstate';
 import { reveal } from './utils/secret';
 import Tree from './utils/tree';
 import thunk from './thunk';

--- a/src/types/array.js
+++ b/src/types/array.js
@@ -6,14 +6,14 @@ export default class ArrayType {
   constructor(value = []) {
     return value instanceof Array ? value : [value];
   }
-  push(current, ...args) {
-    return [...current, ...args];
+  push(...args) {
+    return [...this.state, ...args];
   }
-  filter(current, callback) {
-    return Array.prototype.filter.call(current, callback);
+  filter(callback) {
+    return Array.prototype.filter.call(this.state, callback);
   }
-  map(current, callback) {
-    return Array.prototype.map.call(current, callback);
+  map(callback) {
+    return Array.prototype.map.call(this.state, callback);
   }
   /**
    * Return a new array with first occurance of found item
@@ -24,16 +24,15 @@ export default class ArrayType {
    * let ms = microstate(MS.Array, ['a', 'b', 'c']);
    * // => [ d, b, c ]
    * ```
-   * @param {Array} current
    * @param {any} item
    * @param {any} replacement
    */
-  replace(current, item, replacement) {
-    let index = indexOf(item, current);
+  replace(item, replacement) {
+    let index = indexOf(item, this.state);
     if (index === -1) {
-      return current;
+      return this.state;
     } else {
-      return set(lensPath([index]), replacement, current);
+      return set(lensPath([index]), replacement, this.state);
     }
   }
 }

--- a/src/types/boolean.js
+++ b/src/types/boolean.js
@@ -2,7 +2,7 @@ export default class BooleanType {
   constructor(value = false) {
     return new Boolean(value);
   }
-  toggle(current) {
-    return !current;
+  toggle() {
+    return !this.state;
   }
 }

--- a/src/types/number.js
+++ b/src/types/number.js
@@ -2,16 +2,16 @@ export default class NumberType {
   constructor(value = 0) {
     return new Number(value);
   }
-  sum(current, ...args) {
-    return args.reduce((accumulator, value) => accumulator + value, current);
+  sum(...args) {
+    return args.reduce((accumulator, value) => accumulator + value, this.state);
   }
-  subtract(current, ...args) {
-    return args.reduce((accumulator, value) => accumulator - value, current);
+  subtract(...args) {
+    return args.reduce((accumulator, value) => accumulator - value, this.state);
   }
-  increment(current, step = 1) {
-    return current + step;
+  increment(step = 1) {
+    return this.state + step;
   }
-  decrement(current, step = 1) {
-    return current - step;
+  decrement(step = 1) {
+    return this.state - step;
   }
 }

--- a/src/types/object.js
+++ b/src/types/object.js
@@ -2,7 +2,7 @@ export default class ObjectType {
   constructor(value = {}) {
     return new Object(value);
   }
-  assign(current, props) {
-    return Object.assign({}, current, props);
+  assign(props) {
+    return Object.assign({}, this.state, props);
   }
 }

--- a/src/types/string.js
+++ b/src/types/string.js
@@ -2,7 +2,7 @@ export default class StringType {
   constructor(value = '') {
     return new String(value);
   }
-  concat(current, ...args) {
-    return String.prototype.concat.apply(current, args);
+  concat(...args) {
+    return String.prototype.concat.apply(this.state, args);
   }
 }

--- a/src/utils/equals.js
+++ b/src/utils/equals.js
@@ -1,1 +1,0 @@
-export { default } from 'ramda/src/equals';

--- a/src/utils/get-type.js
+++ b/src/utils/get-type.js
@@ -1,4 +1,8 @@
-import * as MS from '../index';
+import StringType from '../types/string';
+import BooleanType from '../types/boolean';
+import NumberType from '../types/Number';
+import ObjectType from '../types/object';
+import ArrayType from '../types/array';
 
 const { getPrototypeOf } = Object;
 
@@ -6,22 +10,43 @@ const { getPrototypeOf } = Object;
  * Returns microstate type for a value.
  */
 export default function getType(value) {
-  if (Array.isArray(value)) {
-    return MS.Array;
+  let type = typeof value;
+  if (type === "function") {
+    switch (value) {
+      case Number:
+        type = "number";
+        break;
+      case String:
+        type = "string";
+        break;
+      case Boolean:
+        type = "boolean";
+        break;
+      case Object:
+        type = "object";
+        break;
+      case Array:
+        type = "array";
+        break;
+    }
   }
-  switch (typeof value) {
-    case 'number':
-      return MS.Number;
-    case 'string':
-      return MS.String;
-    case 'boolean':
-      return MS.Boolean;
-    case 'object':
+  if (type === "array" || Array.isArray(value)) {
+    return ArrayType;
+  }
+  switch (type) {
+    case "number":
+      return NumberType;
+    case "string":
+      return StringType;
+    case "boolean":
+      return BooleanType;
+    case "object":
       let constructor = getPrototypeOf(value).constructor;
-      if (constructor === Object) {
-        return MS.Object;
+      if (value === Object || constructor === Object) {
+        return ObjectType;
       } else {
         return constructor;
       }
   }
+  return value;
 }

--- a/src/utils/get-type.js
+++ b/src/utils/get-type.js
@@ -1,6 +1,6 @@
 import StringType from '../types/string';
 import BooleanType from '../types/boolean';
-import NumberType from '../types/Number';
+import NumberType from '../types/number';
 import ObjectType from '../types/object';
 import ArrayType from '../types/array';
 

--- a/src/utils/transitions-for.js
+++ b/src/utils/transitions-for.js
@@ -7,18 +7,18 @@ import getType from './get-type';
 
 import isPrimitive from './is-primitive';
 
-const set = function set(current, Type, value) {
-  if (arguments.length === 3) {
+const set = function set(Type, value) {
+  if (arguments.length === 2) {
     return Microstate.create(Type, value);
-  } else if (arguments.length === 2 && typeof Type === 'function') {
-    return Microstate.create(Type);
-  } else if (arguments.length === 2) {
+  } else if (arguments.length === 1 && typeof Type === 'function') {
+    return Microstate.create(Type, this.valueOf());
+  } else if (arguments.length === 1) {
     return Type;
   }
 };
 
-const merge = function merge(current, ...args) {
-  return mergeDeepRight(current, ...args);
+const merge = function merge(...args) {
+  return mergeDeepRight(this.state, ...args);
 };
 
 export default function transitionsFor(Type) {

--- a/src/utils/transitions-for.js
+++ b/src/utils/transitions-for.js
@@ -7,14 +7,8 @@ import getType from './get-type';
 
 import isPrimitive from './is-primitive';
 
-const set = function set(Type, value) {
-  if (arguments.length === 2) {
-    return Microstate.create(Type, value);
-  } else if (arguments.length === 1 && typeof Type === 'function') {
-    return Microstate.create(Type, this.valueOf());
-  } else if (arguments.length === 1) {
-    return Type;
-  }
+const set = function set(value) {
+  return value;
 };
 
 const merge = function merge(...args) {

--- a/src/utils/transitions-for.js
+++ b/src/utils/transitions-for.js
@@ -1,12 +1,19 @@
-import $ from './chain';
 import { append } from 'funcadelic';
+import $ from './chain';
 import mergeDeepRight from 'ramda/src/mergeDeepRight';
 import getPrototypeDescriptors from './get-prototype-descriptors';
+import create from '../microstate';
 
 import isPrimitive from './is-primitive';
 
-const set = function set(current, state) {
-  return state;
+const set = function set(current, Type, value) {
+  if (arguments.length === 3) {
+    return create(Type, value);
+  } else if (arguments.length === 2 && typeof Type === 'function') {
+    return create(Type);
+  } else if (arguments.length === 2) {
+    return Type;
+  }
 };
 
 const merge = function merge(current, ...args) {

--- a/src/utils/transitions-for.js
+++ b/src/utils/transitions-for.js
@@ -2,16 +2,16 @@ import { append } from 'funcadelic';
 import $ from './chain';
 import mergeDeepRight from 'ramda/src/mergeDeepRight';
 import getPrototypeDescriptors from './get-prototype-descriptors';
-import create from '../microstate';
+import Microstate from '../microstate';
 import getType from './get-type';
 
 import isPrimitive from './is-primitive';
 
 const set = function set(current, Type, value) {
   if (arguments.length === 3) {
-    return create(Type, value);
+    return Microstate.create(Type, value);
   } else if (arguments.length === 2 && typeof Type === 'function') {
-    return create(Type);
+    return Microstate.create(Type);
   } else if (arguments.length === 2) {
     return Type;
   }

--- a/src/utils/transitions-for.js
+++ b/src/utils/transitions-for.js
@@ -3,6 +3,7 @@ import $ from './chain';
 import mergeDeepRight from 'ramda/src/mergeDeepRight';
 import getPrototypeDescriptors from './get-prototype-descriptors';
 import create from '../microstate';
+import getType from './get-type';
 
 import isPrimitive from './is-primitive';
 
@@ -21,7 +22,7 @@ const merge = function merge(current, ...args) {
 };
 
 export default function transitionsFor(Type) {
-  let descriptors = getPrototypeDescriptors(Type);
+  let descriptors = getPrototypeDescriptors(getType(Type));
 
   let transitionFns = $(descriptors)
     .filter(({ value }) => isFunctionDescriptor(value))

--- a/src/utils/tree.js
+++ b/src/utils/tree.js
@@ -1,6 +1,6 @@
+import { append, filter, reduce, map } from 'funcadelic';
 import $ from './chain';
 import thunk from '../thunk';
-import { append, filter, reduce, map } from 'funcadelic';
 import getOwnPropertyDescriptors from 'object.getownpropertydescriptors';
 
 let { keys } = Object;

--- a/tests/computed-properties.test.js
+++ b/tests/computed-properties.test.js
@@ -11,7 +11,7 @@ class State {
   }
 
   toUpperCase(state) {
-    return this()
+    return this
       .firstName.set(state.firstName.toUpperCase())
       .lastName.set(state.lastName.toUpperCase());
   }

--- a/tests/computed-properties.test.js
+++ b/tests/computed-properties.test.js
@@ -1,10 +1,10 @@
 import 'jest';
 import { map } from 'funcadelic';
-import microstate, * as MS from '../src';
+import create from '../src';
 
 class State {
-  firstName = MS.String;
-  lastName = MS.String;
+  firstName = String;
+  lastName = String;
 
   get fullName() {
     return `${this.firstName} ${this.lastName}`;
@@ -20,7 +20,7 @@ class State {
 describe('without initial state', () => {
   let ms;
   beforeEach(() => {
-    ms = microstate(State);
+    ms = create(State);
   });
   it('is computed', function() {
     expect(ms.state.fullName).toEqual(' ');
@@ -29,7 +29,7 @@ describe('without initial state', () => {
 describe('with initial state', () => {
   let ms;
   beforeEach(() => {
-    ms = microstate(State, { firstName: 'Peter', lastName: 'Griffin' });
+    ms = create(State, { firstName: 'Peter', lastName: 'Griffin' });
   });
   it('is computed', () => {
     expect(ms.state.fullName).toEqual('Peter Griffin');

--- a/tests/computed-properties.test.js
+++ b/tests/computed-properties.test.js
@@ -10,10 +10,10 @@ class State {
     return `${this.firstName} ${this.lastName}`;
   }
 
-  toUpperCase(state) {
+  toUpperCase() {
     return this
-      .firstName.set(state.firstName.toUpperCase())
-      .lastName.set(state.lastName.toUpperCase());
+      .firstName.set(this.state.firstName.toUpperCase())
+      .lastName.set(this.state.lastName.toUpperCase());
   }
 }
 

--- a/tests/computed-properties.test.js
+++ b/tests/computed-properties.test.js
@@ -1,6 +1,6 @@
 import 'jest';
 import { map } from 'funcadelic';
-import create from '../src';
+import Microstate from '../src';
 
 class State {
   firstName = String;
@@ -20,7 +20,7 @@ class State {
 describe('without initial state', () => {
   let ms;
   beforeEach(() => {
-    ms = create(State);
+    ms = Microstate.create(State);
   });
   it('is computed', function() {
     expect(ms.state.fullName).toEqual(' ');
@@ -29,7 +29,7 @@ describe('without initial state', () => {
 describe('with initial state', () => {
   let ms;
   beforeEach(() => {
-    ms = create(State, { firstName: 'Peter', lastName: 'Griffin' });
+    ms = Microstate.create(State, { firstName: 'Peter', lastName: 'Griffin' });
   });
   it('is computed', () => {
     expect(ms.state.fullName).toEqual('Peter Griffin');

--- a/tests/constants.test.js
+++ b/tests/constants.test.js
@@ -1,6 +1,6 @@
 import 'jest';
 import { map } from 'funcadelic';
-import microstate, * as MS from '../src';
+import create from '../src';
 
 class Type {
   n = 10;
@@ -9,13 +9,13 @@ class Type {
   o = { hello: 'world' };
   a = ['a', 'b', 'c'];
   null = null;
-  greeting = MS.String;
+  greeting = String;
 }
 
 describe('constants support', () => {
   let ms, next;
   beforeEach(() => {
-    ms = microstate(Type);
+    ms = create(Type);
     next = ms.greeting.set('HI');
   });
   it('includes constants in state tree', () => {
@@ -47,6 +47,6 @@ describe('constants support', () => {
     expect(next.valueOf()).toEqual({ greeting: 'HI' });
   });
   it.skip('shares complex objects between multiple instances of microstate', () => {
-    expect(ms.state.o).toBe(microstate(Type).state.o);
+    expect(ms.state.o).toBe(create(Type).state.o);
   });
 });

--- a/tests/constants.test.js
+++ b/tests/constants.test.js
@@ -1,6 +1,6 @@
 import 'jest';
 import { map } from 'funcadelic';
-import create from '../src';
+import Microstate from '../src';
 
 class Type {
   n = 10;
@@ -15,7 +15,7 @@ class Type {
 describe('constants support', () => {
   let ms, next;
   beforeEach(() => {
-    ms = create(Type);
+    ms = Microstate.create(Type);
     next = ms.greeting.set('HI');
   });
   it('includes constants in state tree', () => {

--- a/tests/deep-composition.test.js
+++ b/tests/deep-composition.test.js
@@ -1,12 +1,12 @@
 import 'jest';
 import { map } from 'funcadelic';
-import microstate, * as MS from '../src';
+import create from '../src';
 
 class Session {
-  token = MS.String;
+  token = String;
 }
 class Authentication {
-  isAuthenticated = MS.Boolean;
+  isAuthenticated = Boolean;
   session = Session;
 }
 class State {
@@ -15,7 +15,7 @@ class State {
 describe('without initial state', () => {
   let ms;
   beforeEach(() => {
-    ms = microstate(State);
+    ms = create(State);
   });
   it('builds state tree', () => {
     expect(ms.state).toMatchObject({
@@ -37,7 +37,7 @@ describe('without initial state', () => {
 describe('with initial state', () => {
   let ms;
   beforeEach(() => {
-    ms = microstate(State, {
+    ms = create(State, {
       authentication: { isAuthenticated: true, session: { token: 'SECRET' } },
     });
   });

--- a/tests/deep-composition.test.js
+++ b/tests/deep-composition.test.js
@@ -1,6 +1,6 @@
 import 'jest';
 import { map } from 'funcadelic';
-import create from '../src';
+import Microstate from '../src';
 
 class Session {
   token = String;
@@ -15,7 +15,7 @@ class State {
 describe('without initial state', () => {
   let ms;
   beforeEach(() => {
-    ms = create(State);
+    ms = Microstate.create(State);
   });
   it('builds state tree', () => {
     expect(ms.state).toMatchObject({
@@ -37,7 +37,7 @@ describe('without initial state', () => {
 describe('with initial state', () => {
   let ms;
   beforeEach(() => {
-    ms = create(State, {
+    ms = Microstate.create(State, {
       authentication: { isAuthenticated: true, session: { token: 'SECRET' } },
     });
   });

--- a/tests/examples/authentication.test.js
+++ b/tests/examples/authentication.test.js
@@ -18,7 +18,7 @@ class AuthenticatedSession {
   content = MS.Object;
 
   logout() {
-    return this(AnonymousSession);
+    return this.set(AnonymousSession);
   }
 }
 
@@ -26,7 +26,7 @@ class AnonymousSession {
   content = null;
   isAuthenticated = false;
   authenticate(current, user) {
-    return this(AuthenticatedSession, { content: user });
+    return this.set(AuthenticatedSession, { content: user });
   }
 }
 

--- a/tests/examples/authentication.test.js
+++ b/tests/examples/authentication.test.js
@@ -1,6 +1,6 @@
 import 'jest';
 import { map } from 'funcadelic';
-import Microstate from '../../src';
+import { create } from '../../src';
 
 class Session {
   content = null;
@@ -18,7 +18,7 @@ class AuthenticatedSession {
   content = Object;
 
   logout() {
-    return this.set(AnonymousSession);
+    return create(AnonymousSession);
   }
 }
 
@@ -26,7 +26,7 @@ class AnonymousSession {
   content = null;
   isAuthenticated = false;
   authenticate(user) {
-    return this.set(AuthenticatedSession, { content: user });
+    return create(AuthenticatedSession, { content: user });
   }
 }
 
@@ -37,7 +37,7 @@ class MyApp {
 describe('AnonymousSession', () => {
   let ms, authenticated;
   beforeEach(() => {
-    ms = Microstate.create(MyApp);
+    ms = create(MyApp);
     authenticated = ms.session.authenticate({
       name: 'Charles',
     });
@@ -57,7 +57,7 @@ describe('AnonymousSession', () => {
 describe('AuthenticatedSession', () => {
   let ms, anonymous;
   beforeEach(() => {
-    ms = Microstate.create(MyApp, { session: { name: 'Taras' } })
+    ms = create(MyApp, { session: { name: 'Taras' } })
     anonymous = ms.session.logout();
   });
   it('initializes into AuthenticatedSession state', () => {

--- a/tests/examples/authentication.test.js
+++ b/tests/examples/authentication.test.js
@@ -1,6 +1,6 @@
 import 'jest';
 import { map } from 'funcadelic';
-import create from '../../src';
+import Microstate from '../../src';
 
 class Session {
   content = null;
@@ -37,7 +37,7 @@ class MyApp {
 describe('AnonymousSession', () => {
   let ms, authenticated;
   beforeEach(() => {
-    ms = create(MyApp);
+    ms = Microstate.create(MyApp);
     authenticated = ms.session.authenticate({
       name: 'Charles',
     });
@@ -57,7 +57,7 @@ describe('AnonymousSession', () => {
 describe('AuthenticatedSession', () => {
   let ms, anonymous;
   beforeEach(() => {
-    ms = create(MyApp, { session: { name: 'Taras' } })
+    ms = Microstate.create(MyApp, { session: { name: 'Taras' } })
     anonymous = ms.session.logout();
   });
   it('initializes into AuthenticatedSession state', () => {

--- a/tests/examples/authentication.test.js
+++ b/tests/examples/authentication.test.js
@@ -1,6 +1,6 @@
 import 'jest';
 import { map } from 'funcadelic';
-import create, * as MS from '../../src';
+import create from '../../src';
 
 class Session {
   content = null;
@@ -15,7 +15,7 @@ class Session {
 
 class AuthenticatedSession {
   isAuthenticated = true;
-  content = MS.Object;
+  content = Object;
 
   logout() {
     return this.set(AnonymousSession);

--- a/tests/examples/authentication.test.js
+++ b/tests/examples/authentication.test.js
@@ -25,7 +25,7 @@ class AuthenticatedSession {
 class AnonymousSession {
   content = null;
   isAuthenticated = false;
-  authenticate(current, user) {
+  authenticate(user) {
     return this.set(AuthenticatedSession, { content: user });
   }
 }

--- a/tests/examples/cart.test.js
+++ b/tests/examples/cart.test.js
@@ -1,10 +1,10 @@
 import 'jest';
 import { map } from 'funcadelic';
-import microstate, * as MS from '../../src';
+import create from '../../src';
 
 describe('cart example', () => {
   class Cart {
-    products = MS.Array;
+    products = Array;
     get price() {
       return this.products.reduce((acc, product) => acc + product.quantity * product.price, 0);
     }
@@ -15,7 +15,7 @@ describe('cart example', () => {
   describe('adding products without initial value', () => {
     let ms;
     beforeEach(() => {
-      ms = microstate(Cart)
+      ms = create(Cart)
         .products.push({ quantity: 1, price: 10 })
         .products.push({ quantity: 2, price: 20 });
     });

--- a/tests/examples/cart.test.js
+++ b/tests/examples/cart.test.js
@@ -1,6 +1,6 @@
 import 'jest';
 import { map } from 'funcadelic';
-import create from '../../src';
+import Microstate from '../../src';
 
 describe('cart example', () => {
   class Cart {
@@ -15,7 +15,7 @@ describe('cart example', () => {
   describe('adding products without initial value', () => {
     let ms;
     beforeEach(() => {
-      ms = create(Cart)
+      ms = Microstate.create(Cart)
         .products.push({ quantity: 1, price: 10 })
         .products.push({ quantity: 2, price: 20 });
     });

--- a/tests/microstate.test.js
+++ b/tests/microstate.test.js
@@ -1,12 +1,12 @@
 import 'jest';
 import { map } from 'funcadelic';
-import create from '../src';
+import Microstate from '../src';
 import { reveal } from '../src/utils/secret';
 
 describe('microstate', () => {
   it('throws an error when a transition called state is defined', () => {
     expect(function() {
-      create(
+      Microstate.create(
         class MyClass {
           state() {}
         }
@@ -17,14 +17,14 @@ describe('microstate', () => {
   });
   it('throws an error when state property is set', () => {
     expect(function() {
-      create(Number).state = 10;
+      Microstate.create(Number).state = 10;
     }).toThrowError(`Setting state property will not do anything useful. Please don't do this.`);
   });
   
   describe('valueOf', () => {
     let ms;
     beforeEach(() => {
-      ms = create(Number, 10);
+      ms = Microstate.create(Number, 10);
     });
     it('returns passed in value of', () => {
       expect(ms.valueOf()).toBe(10);

--- a/tests/microstate.test.js
+++ b/tests/microstate.test.js
@@ -1,36 +1,38 @@
 import 'jest';
 import { map } from 'funcadelic';
-import Microstate from '../src';
+import Microstate, { create } from '../src';
 import { reveal } from '../src/utils/secret';
 
-describe('microstate', () => {
-  it('throws an error when a transition called state is defined', () => {
-    expect(function() {
-      Microstate.create(
-        class MyClass {
-          state() {}
-        }
-      );
-    }).toThrowError(
-      `You can not use 'state' as transition name because it'll conflict with state property on the microstate.`
+it('exports create', function() {
+  expect(create).toBeInstanceOf(Function);
+});
+
+it('throws an error when a transition called state is defined', () => {
+  expect(function() {
+    Microstate.create(
+      class MyClass {
+        state() {}
+      }
     );
+  }).toThrowError(
+    `You can not use 'state' as transition name because it'll conflict with state property on the microstate.`
+  );
+});
+it('throws an error when state property is set', () => {
+  expect(function() {
+    Microstate.create(Number).state = 10;
+  }).toThrowError(`Setting state property will not do anything useful. Please don't do this.`);
+});
+
+describe('valueOf', () => {
+  let ms;
+  beforeEach(() => {
+    ms = Microstate.create(Number, 10);
   });
-  it('throws an error when state property is set', () => {
-    expect(function() {
-      Microstate.create(Number).state = 10;
-    }).toThrowError(`Setting state property will not do anything useful. Please don't do this.`);
+  it('returns passed in value of', () => {
+    expect(ms.valueOf()).toBe(10);
   });
-  
-  describe('valueOf', () => {
-    let ms;
-    beforeEach(() => {
-      ms = Microstate.create(Number, 10);
-    });
-    it('returns passed in value of', () => {
-      expect(ms.valueOf()).toBe(10);
-    });
-    it('is not enumerable', () => {
-      expect(Object.keys(ms).indexOf('valueOf')).toBe(-1);
-    });
+  it('is not enumerable', () => {
+    expect(Object.keys(ms).indexOf('valueOf')).toBe(-1);
   });
 });

--- a/tests/microstate.test.js
+++ b/tests/microstate.test.js
@@ -1,6 +1,6 @@
 import 'jest';
 import { map } from 'funcadelic';
-import create, * as MS from '../src';
+import create from '../src';
 import { reveal } from '../src/utils/secret';
 
 describe('microstate', () => {
@@ -17,14 +17,14 @@ describe('microstate', () => {
   });
   it('throws an error when state property is set', () => {
     expect(function() {
-      create(MS.Number).state = 10;
+      create(Number).state = 10;
     }).toThrowError(`Setting state property will not do anything useful. Please don't do this.`);
   });
   
   describe('valueOf', () => {
     let ms;
     beforeEach(() => {
-      ms = create(MS.Number, 10);
+      ms = create(Number, 10);
     });
     it('returns passed in value of', () => {
       expect(ms.valueOf()).toBe(10);

--- a/tests/recursive-composition.test.js
+++ b/tests/recursive-composition.test.js
@@ -1,17 +1,17 @@
 import 'jest';
 import { map } from 'funcadelic';
-import microstate, * as MS from '../src';
+import create from '../src';
 
 class Container {
   contains = Container;
-  x = MS.Number;
-  y = MS.Number;
+  x = Number;
+  y = Number;
 }
 
 describe('without initial value', () => {
   let ms;
   beforeEach(() => {
-    ms = microstate(Container);
+    ms = create(Container);
   });
   it('initializes first level', () => {
     expect(ms.state).toMatchObject({
@@ -47,7 +47,7 @@ describe('without initial value', () => {
 describe('with initial value', () => {
   let ms;
   beforeEach(() => {
-    ms = microstate(Container, {
+    ms = create(Container, {
       x: 10,
       y: 0,
       contains: { y: 20, x: 0, contains: { x: 30, y: 25, contains: {} } },

--- a/tests/recursive-composition.test.js
+++ b/tests/recursive-composition.test.js
@@ -1,6 +1,6 @@
 import 'jest';
 import { map } from 'funcadelic';
-import create from '../src';
+import Microstate from '../src';
 
 class Container {
   contains = Container;
@@ -11,7 +11,7 @@ class Container {
 describe('without initial value', () => {
   let ms;
   beforeEach(() => {
-    ms = create(Container);
+    ms = Microstate.create(Container);
   });
   it('initializes first level', () => {
     expect(ms.state).toMatchObject({
@@ -47,7 +47,7 @@ describe('without initial value', () => {
 describe('with initial value', () => {
   let ms;
   beforeEach(() => {
-    ms = create(Container, {
+    ms = Microstate.create(Container, {
       x: 10,
       y: 0,
       contains: { y: 20, x: 0, contains: { x: 30, y: 25, contains: {} } },

--- a/tests/shallow-composition.test.js
+++ b/tests/shallow-composition.test.js
@@ -1,16 +1,16 @@
 import 'jest';
 import { map } from 'funcadelic';
-import microstate, * as MS from '../src';
+import create from '../src';
 
 class Modal {
-  name = MS.String;
-  isOpen = MS.Boolean;
+  name = String;
+  isOpen = Boolean;
 }
 describe('types', () => {
   describe('value', () => {
     let ms;
     beforeEach(() => {
-      ms = microstate(Modal);
+      ms = create(Modal);
     });
     it('is instance of Modal', () => {
       expect(ms.state).toBeInstanceOf(Modal);
@@ -42,7 +42,7 @@ describe('types', () => {
   describe('no value', () => {
     let ms, set, merged;
     beforeEach(() => {
-      ms = microstate(Modal, { isOpen: true });
+      ms = create(Modal, { isOpen: true });
       set = ms.name.set('taras');
       merged = ms.merge({ name: 'taras' });
     });
@@ -60,13 +60,13 @@ describe('types', () => {
 
 describe('arrays and objects', () => {
   class State {
-    animals = MS.Array;
-    config = MS.Object;
+    animals = Array;
+    config = Object;
   }
   describe('value', () => {
     let ms;
     beforeEach(() => {
-      ms = microstate(State);
+      ms = create(State);
     });
     it('initialies with default', () => {
       expect(ms.state).toEqual({
@@ -88,7 +88,7 @@ describe('arrays and objects', () => {
   describe('no value', () => {
     let ms;
     beforeEach(() => {
-      ms = microstate(State, { animals: ['cat', 'dog'], config: { color: 'red' } });
+      ms = create(State, { animals: ['cat', 'dog'], config: { color: 'red' } });
     });
     it('uses provided value', () => {
       expect(ms.state).toEqual({

--- a/tests/shallow-composition.test.js
+++ b/tests/shallow-composition.test.js
@@ -1,6 +1,6 @@
 import 'jest';
 import { map } from 'funcadelic';
-import create from '../src';
+import Microstate from '../src';
 
 class Modal {
   name = String;
@@ -10,7 +10,7 @@ describe('types', () => {
   describe('value', () => {
     let ms;
     beforeEach(() => {
-      ms = create(Modal);
+      ms = Microstate.create(Modal);
     });
     it('is instance of Modal', () => {
       expect(ms.state).toBeInstanceOf(Modal);
@@ -42,7 +42,7 @@ describe('types', () => {
   describe('no value', () => {
     let ms, set, merged;
     beforeEach(() => {
-      ms = create(Modal, { isOpen: true });
+      ms = Microstate.create(Modal, { isOpen: true });
       set = ms.name.set('taras');
       merged = ms.merge({ name: 'taras' });
     });
@@ -66,7 +66,7 @@ describe('arrays and objects', () => {
   describe('value', () => {
     let ms;
     beforeEach(() => {
-      ms = create(State);
+      ms = Microstate.create(State);
     });
     it('initialies with default', () => {
       expect(ms.state).toEqual({
@@ -88,7 +88,7 @@ describe('arrays and objects', () => {
   describe('no value', () => {
     let ms;
     beforeEach(() => {
-      ms = create(State, { animals: ['cat', 'dog'], config: { color: 'red' } });
+      ms = Microstate.create(State, { animals: ['cat', 'dog'], config: { color: 'red' } });
     });
     it('uses provided value', () => {
       expect(ms.state).toEqual({

--- a/tests/structure.test.js
+++ b/tests/structure.test.js
@@ -7,8 +7,8 @@ import analyze from '../src/structure';
 describe('Structure', () => {
   class Session {
     user = class User {
-      firstName = MS.String;
-      lastName = MS.String;
+      firstName = String;
+      lastName = String;
 
       get fullName() {
         return `${this.firstName} ${this.lastName}`;

--- a/tests/transition-inheritance.test.js
+++ b/tests/transition-inheritance.test.js
@@ -1,6 +1,6 @@
 import 'jest';
 import { map } from 'funcadelic';
-import create, * as MS from '../src';
+import create from '../src';
 
 class Confirmation {
   get isArmed() {

--- a/tests/transition-inheritance.test.js
+++ b/tests/transition-inheritance.test.js
@@ -1,6 +1,6 @@
 import 'jest';
 import { map } from 'funcadelic';
-import Microstate from '../src';
+import { create } from '../src';
 
 class Confirmation {
   get isArmed() {
@@ -11,11 +11,11 @@ class Confirmation {
   }
 
   arm() {
-    return this.set(Armed);
+    return create(Armed);
   }
 
   reset() {
-    return this.set(Confirmation);
+    return create(Confirmation);
   }
 }
 
@@ -25,7 +25,7 @@ class Armed extends Confirmation {
   }
 
   confirm() {
-    return this.set(Confirmed);
+    return create(Confirmed);
   }
 }
 
@@ -35,7 +35,7 @@ class Confirmed extends Confirmation {
   }
 }
 
-let dnd = Microstate.create(Confirmation);
+let dnd = create(Confirmation);
 let armed, confirmed, reset, rearmed, state;
 beforeEach(() => {
   armed = dnd.arm();

--- a/tests/transition-inheritance.test.js
+++ b/tests/transition-inheritance.test.js
@@ -1,6 +1,6 @@
 import 'jest';
 import { map } from 'funcadelic';
-import create from '../src';
+import Microstate from '../src';
 
 class Confirmation {
   get isArmed() {
@@ -35,7 +35,7 @@ class Confirmed extends Confirmation {
   }
 }
 
-let dnd = create(Confirmation);
+let dnd = Microstate.create(Confirmation);
 let armed, confirmed, reset, rearmed, state;
 beforeEach(() => {
   armed = dnd.arm();

--- a/tests/transition-inheritance.test.js
+++ b/tests/transition-inheritance.test.js
@@ -11,11 +11,11 @@ class Confirmation {
   }
 
   arm() {
-    return this(Armed);
+    return this.set(Armed);
   }
 
   reset() {
-    return this(Confirmation);
+    return this.set(Confirmation);
   }
 }
 
@@ -25,7 +25,7 @@ class Armed extends Confirmation {
   }
 
   confirm() {
-    return this(Confirmed);
+    return this.set(Confirmed);
   }
 }
 

--- a/tests/transitions.test.js
+++ b/tests/transitions.test.js
@@ -1,11 +1,12 @@
 import 'jest';
 import { map } from 'funcadelic';
 import create, * as MS from '../src';
+import { Microstate } from '../src/microstate';
 
 class Car {
   speed = MS.Number;
   increaseSpeed(current, amount) {
-    return this().speed.sum(amount);
+    return this.speed.sum(amount);
   }
 }
 class Road {
@@ -67,13 +68,13 @@ describe('context', () => {
     custom();
   });
   it('is a function', () => {
-    expect(context).toBeInstanceOf(Function);
+    expect(context).toBeInstanceOf(Microstate);
   });
   it.skip('excludes custom transtions from context', () => {
-    expect(context()).not.toHaveProperty('custom');
+    expect(context).not.toHaveProperty('custom');
   });
   it('returns transitions', () => {
-    expect(context()).toMatchObject({
+    expect(context).toMatchObject({
       items: {
         push: expect.any(Function),
       },
@@ -96,7 +97,7 @@ describe('merging', () => {
     modal = Modal;
 
     addItemAndShowModal(current, message, prompt) {
-      return this()
+      return this
         .messages.push(message)
         .modal.isOpen.set(true)
         .modal.content.text.set(prompt);

--- a/tests/transitions.test.js
+++ b/tests/transitions.test.js
@@ -53,6 +53,7 @@ describe('transition', () => {
     });
   });
 });
+
 describe('context', () => {
   let context;
   let result;

--- a/tests/transitions.test.js
+++ b/tests/transitions.test.js
@@ -4,7 +4,7 @@ import Microstate from '../src';
 
 class Car {
   speed = Number;
-  increaseSpeed(current, amount) {
+  increaseSpeed(amount) {
     return this.speed.sum(amount);
   }
 }
@@ -95,7 +95,7 @@ describe('merging', () => {
     messages = Array;
     modal = Modal;
 
-    addItemAndShowModal(current, message, prompt) {
+    addItemAndShowModal(message, prompt) {
       return this
         .messages.push(message)
         .modal.isOpen.set(true)

--- a/tests/transitions.test.js
+++ b/tests/transitions.test.js
@@ -1,10 +1,10 @@
 import 'jest';
 import { map } from 'funcadelic';
-import create, * as MS from '../src';
+import create from '../src';
 import { Microstate } from '../src/microstate';
 
 class Car {
-  speed = MS.Number;
+  speed = Number;
   increaseSpeed(current, amount) {
     return this.speed.sum(amount);
   }
@@ -59,7 +59,7 @@ describe('context', () => {
   let result;
   beforeEach(() => {
     class State {
-      items = MS.Array;
+      items = Array;
       custom() {
         context = this;
       }
@@ -85,15 +85,15 @@ describe('context', () => {
 });
 describe('merging', () => {
   class ModalContent {
-    text = MS.String;
+    text = String;
   }
   class Modal {
-    isOpen = MS.Boolean;
-    title = MS.String;
+    isOpen = Boolean;
+    title = String;
     content = ModalContent;
   }
   class State {
-    messages = MS.Array;
+    messages = Array;
     modal = Modal;
 
     addItemAndShowModal(current, message, prompt) {

--- a/tests/transitions.test.js
+++ b/tests/transitions.test.js
@@ -1,7 +1,6 @@
 import 'jest';
 import { map } from 'funcadelic';
-import create from '../src';
-import { Microstate } from '../src/microstate';
+import Microstate from '../src';
 
 class Car {
   speed = Number;
@@ -17,7 +16,7 @@ describe('transition', () => {
   describe('without initial value', () => {
     let ms, faster;
     beforeEach(() => {
-      ms = create(Road);
+      ms = Microstate.create(Road);
       faster = ms.vehicle.increaseSpeed(10);
     });
     it('uses current state value', () => {
@@ -27,7 +26,7 @@ describe('transition', () => {
   describe('with initial value', () => {
     let ms, faster;
     beforeEach(() => {
-      ms = create(Road, { vehicle: { speed: 10 } });
+      ms = Microstate.create(Road, { vehicle: { speed: 10 } });
       faster = ms.vehicle.increaseSpeed(10);
     });
     it('creates initial value', () => {
@@ -37,7 +36,7 @@ describe('transition', () => {
   describe('chained operations', function() {
     let ms, m1, m2, v1, v2;
     beforeEach(() => {
-      ms = create(Road);
+      ms = Microstate.create(Road);
       m1 = ms.vehicle.increaseSpeed(10);
       v1 = m1.valueOf();
       m2 = m1.vehicle.increaseSpeed(20);
@@ -64,7 +63,7 @@ describe('context', () => {
         context = this;
       }
     }
-    let { custom } = create(State);
+    let { custom } = Microstate.create(State);
     custom();
   });
   it('is a function', () => {
@@ -106,7 +105,7 @@ describe('merging', () => {
   let ms;
   let result;
   beforeEach(() => {
-    ms = create(State, { modal: { title: 'Confirmation' } });
+    ms = Microstate.create(State, { modal: { title: 'Confirmation' } });
     result = ms.addItemAndShowModal('Hello World', 'You have a message');
   });
   it('returns merged state', () => {

--- a/tests/type-shifting.test.js
+++ b/tests/type-shifting.test.js
@@ -1,23 +1,23 @@
 import 'jest';
 import { map } from 'funcadelic';
-import create, * as MS from '../src';
+import create from '../src';
 
 describe('type-shifting', () => {
   class Line {
-    a = MS.Number;
+    a = Number;
     add({ a }, b) {
       return this.set(Corner, { a, b });
     }
   }
   class Corner extends Line {
-    a = MS.Number;
-    b = MS.Number;
+    a = Number;
+    b = Number;
     add({ a, b }, c) {
       return this.set(Triangle, { a, b, c });
     }
   }
   class Triangle extends Corner {
-    c = MS.Number;
+    c = Number;
   }
   let ms = create(Line);
   let line, corner, triangle;

--- a/tests/type-shifting.test.js
+++ b/tests/type-shifting.test.js
@@ -1,6 +1,6 @@
 import 'jest';
 import { map } from 'funcadelic';
-import create from '../src';
+import Microstate from '../src';
 
 describe('type-shifting', () => {
   class Line {
@@ -19,7 +19,7 @@ describe('type-shifting', () => {
   class Triangle extends Corner {
     c = Number;
   }
-  let ms = create(Line);
+  let ms = Microstate.create(Line);
   let line, corner, triangle;
   beforeEach(() => {
     line = ms.a.set(10);
@@ -96,7 +96,7 @@ describe('type-shifting with constant values', () => {
     isError = false;
   }
   describe('successful loading siquence', () => {
-    let async = create(Async);
+    let async = Microstate.create(Async);
     it('can transition to loading', () => {
       expect(async.loading().state).toMatchObject({
         content: null,
@@ -115,7 +115,7 @@ describe('type-shifting with constant values', () => {
     });
   });
   describe('error loading sequence', () => {
-    let async = create(Async);
+    let async = Microstate.create(Async);
     it('can transition from loading to error', () => {
       expect(async.loading().error(':(').state).toMatchObject({
         content: null,

--- a/tests/type-shifting.test.js
+++ b/tests/type-shifting.test.js
@@ -5,14 +5,16 @@ import Microstate from '../src';
 describe('type-shifting', () => {
   class Line {
     a = Number;
-    add({ a }, b) {
+    add(b) {
+      let { a } = this.state;
       return this.set(Corner, { a, b });
     }
   }
   class Corner extends Line {
     a = Number;
     b = Number;
-    add({ a, b }, c) {
+    add(c) {
+      let { a, b } = this.state;
       return this.set(Triangle, { a, b, c });
     }
   }
@@ -73,7 +75,7 @@ describe('type-shifting with constant values', () => {
   class AsyncLoading extends Async {
     isLoading = true;
 
-    loaded(current, content) {
+    loaded(content) {
       return this.set(
         class extends AsyncLoaded {
           content = content;
@@ -81,7 +83,7 @@ describe('type-shifting with constant values', () => {
       );
     }
 
-    error(current, msg) {
+    error(msg) {
       return this.set(
         class extends AsyncError {
           error = msg;

--- a/tests/type-shifting.test.js
+++ b/tests/type-shifting.test.js
@@ -6,14 +6,14 @@ describe('type-shifting', () => {
   class Line {
     a = MS.Number;
     add({ a }, b) {
-      return this(Corner, { a, b });
+      return this.set(Corner, { a, b });
     }
   }
   class Corner extends Line {
     a = MS.Number;
     b = MS.Number;
     add({ a, b }, c) {
-      return this(Triangle, { a, b, c });
+      return this.set(Triangle, { a, b, c });
     }
   }
   class Triangle extends Corner {
@@ -60,7 +60,7 @@ describe('type-shifting with constant values', () => {
     isError = false;
 
     loading() {
-      return this(AsyncLoading);
+      return this.set(AsyncLoading);
     }
   }
 
@@ -74,7 +74,7 @@ describe('type-shifting with constant values', () => {
     isLoading = true;
 
     loaded(current, content) {
-      return this(
+      return this.set(
         class extends AsyncLoaded {
           content = content;
         }
@@ -82,7 +82,7 @@ describe('type-shifting with constant values', () => {
     }
 
     error(current, msg) {
-      return this(
+      return this.set(
         class extends AsyncError {
           error = msg;
         }

--- a/tests/typeclasses.test.js
+++ b/tests/typeclasses.test.js
@@ -1,22 +1,22 @@
 import "jest";
 import { map } from "funcadelic";
-import create, * as MS from "../src";
+import create from "../src";
 import { flatMap } from '../src/monad';
 import { Microstate } from "../src/microstate";
 
 describe("typeclasses", () => {
   class Home {
-    city = MS.String;
+    city = String;
   }
 
   class Person {
-    name = MS.String;
+    name = String;
     home = Home;
   }
 
   let simple, complex;
   beforeEach(() => {
-    simple = create(MS.Number, 10);
+    simple = create(Number, 10);
     complex = create(Person, { name: "Taras", home: { city: "Toronto" } });
   })
 

--- a/tests/typeclasses.test.js
+++ b/tests/typeclasses.test.js
@@ -1,8 +1,7 @@
 import "jest";
 import { map } from "funcadelic";
-import create from "../src";
 import { flatMap } from '../src/monad';
-import { Microstate } from "../src/microstate";
+import Microstate  from "../src";
 
 describe("typeclasses", () => {
   class Home {
@@ -16,8 +15,8 @@ describe("typeclasses", () => {
 
   let simple, complex;
   beforeEach(() => {
-    simple = create(Number, 10);
-    complex = create(Person, { name: "Taras", home: { city: "Toronto" } });
+    simple = Microstate.create(Number, 10);
+    complex = Microstate.create(Person, { name: "Taras", home: { city: "Toronto" } });
   })
 
   describe("functor", function() {  

--- a/tests/types/array.test.js
+++ b/tests/types/array.test.js
@@ -1,42 +1,40 @@
 import 'jest';
 
+import 'funcadelic';
 import ArrayType from '../../src/types/array';
-import microstate, * as MS from '../../src';
+import create from '../../src';
 
-describe('array', () => {
-  let array = ['a', 'b', 'c'];
-  let ms = microstate(MS.Array, array);
-  describe('constructor', () => {
-    it('returns an array when receives another value', () => {
-      expect(new MS.Array()).toEqual([]);
-      expect(new MS.Array('foo')).toEqual(['foo']);
-      expect(new MS.Array(false)).toEqual([false]);
-    });
-    it('returns the array when one is passed', () => {
-      expect(new MS.Array(array)).toBe(array);
-    });
-  });
-  describe('filter', () => {
-    it('removes items', () => {
-      expect(ms.filter(v => v !== 'a').valueOf()).toEqual(['b', 'c']);
-    });
-  });
-  describe('map', () => {
-    it('applies to every item', () => {
-      expect(ms.map(v => v.toUpperCase()).valueOf()).toEqual(['A', 'B', 'C']);
-    });
-  });
-  describe('replace', () => {
-    it('replaces first element', () => {
-      expect(ms.replace('a', 'd').valueOf()).toEqual(['d', 'b', 'c']);
-    });
-    it('does not throw when replacing non-existing item', () => {
-      expect(() => {
-        ms.replace('e', 'd');
-      }).not.toThrow();
-    });
-    it('returns same array when value not found', () => {
-      expect(ms.replace('e', 'd').valueOf()).toBe(array);
-    });
-  });
+let array = ['a', 'b', 'c'];
+let ms = create(Array, array);
+
+it('constructor returns an array when receives another value', () => {
+  expect(new ArrayType()).toEqual([]);
+  expect(new ArrayType('foo')).toEqual(['foo']);
+  expect(new ArrayType(false)).toEqual([false]);
+});
+
+it('constructor returns the array when one is passed', () => {
+  expect(new ArrayType(array)).toBe(array);
+});
+
+it('filter removes items', () => {
+  expect(ms.filter(v => v !== 'a').valueOf()).toEqual(['b', 'c']);
+});
+
+it('map applies to every item', () => {
+  expect(ms.map(v => v.toUpperCase()).valueOf()).toEqual(['A', 'B', 'C']);
+});
+
+it('replace replaces first element', () => {
+  expect(ms.replace('a', 'd').valueOf()).toEqual(['d', 'b', 'c']);
+});
+
+it('replace does not throw when replacing non-existing item', () => {
+  expect(() => {
+    ms.replace('e', 'd');
+  }).not.toThrow();
+});
+
+it('replace returns same array when value not found', () => {
+  expect(ms.replace('e', 'd').valueOf()).toBe(array);
 });

--- a/tests/types/array.test.js
+++ b/tests/types/array.test.js
@@ -2,10 +2,10 @@ import 'jest';
 
 import 'funcadelic';
 import ArrayType from '../../src/types/array';
-import create from '../../src';
+import Microstate from '../../src';
 
 let array = ['a', 'b', 'c'];
-let ms = create(Array, array);
+let ms = Microstate.create(Array, array);
 
 it('constructor returns an array when receives another value', () => {
   expect(new ArrayType()).toEqual([]);

--- a/tests/types/boolean.test.js
+++ b/tests/types/boolean.test.js
@@ -1,9 +1,9 @@
 import 'jest';
 
-import microstate, * as MS from '../../src';
+import create from '../../src';
 
 describe('boolean', () => {
-  let ms = microstate(MS.Boolean);
+  let ms = create(Boolean);
   it('toggles', () => {
     expect(ms.valueOf()).toBeFalsy();
     expect(ms.toggle().valueOf()).toBe(true);

--- a/tests/types/boolean.test.js
+++ b/tests/types/boolean.test.js
@@ -1,9 +1,9 @@
 import 'jest';
 
-import create from '../../src';
+import Microstate from '../../src';
 
 describe('boolean', () => {
-  let ms = create(Boolean);
+  let ms = Microstate.create(Boolean);
   it('toggles', () => {
     expect(ms.valueOf()).toBeFalsy();
     expect(ms.toggle().valueOf()).toBe(true);

--- a/tests/types/number.test.js
+++ b/tests/types/number.test.js
@@ -1,12 +1,12 @@
 import "jest";
 
-import create from "../../src";
+import Microstate from "../../src";
 
 describe("number", () => {
   let zero, ten;
   beforeEach(() => {
-    zero = create(Number);
-    ten = create(Number, 10);
+    zero = Microstate.create(Number);
+    ten = Microstate.create(Number, 10);
   });
   it("has transitions", () => {
     expect(zero).toMatchObject({

--- a/tests/types/number.test.js
+++ b/tests/types/number.test.js
@@ -1,12 +1,12 @@
 import "jest";
 
-import microstate, * as MS from "../../src";
+import create from "../../src";
 
 describe("number", () => {
   let zero, ten;
   beforeEach(() => {
-    zero = microstate(MS.Number);
-    ten = microstate(MS.Number, 10);
+    zero = create(Number);
+    ten = create(Number, 10);
   });
   it("has transitions", () => {
     expect(zero).toMatchObject({

--- a/tests/types/string.test.js
+++ b/tests/types/string.test.js
@@ -1,9 +1,9 @@
 import 'jest';
 
-import create from '../../src';
+import Microstate from '../../src';
 
 describe('string transitions', () => {
-  let ms = create(String);
+  let ms = Microstate.create(String);
   it('concat', () => {
     expect(ms.concat(' foo').valueOf()).toBe(' foo');
   });

--- a/tests/types/string.test.js
+++ b/tests/types/string.test.js
@@ -1,9 +1,9 @@
 import 'jest';
 
-import microstate, * as MS from '../../src';
+import create from '../../src';
 
 describe('string transitions', () => {
-  let ms = microstate(MS.String);
+  let ms = create(String);
   it('concat', () => {
     expect(ms.concat(' foo').valueOf()).toBe(' foo');
   });

--- a/tests/utils/get-type.test.js
+++ b/tests/utils/get-type.test.js
@@ -1,0 +1,26 @@
+import 'jest';
+import prettyFormat from 'pretty-format';
+import { map } from 'funcadelic';
+import getType from '../../src/utils/get-type';
+import BooleanType from '../../src/types/boolean';
+import NumberType from '../../src/types/number';
+import ObjectType from '../../src/types/object';
+import StringType from '../../src/types/string';
+import ArrayType from '../../src/types/array';
+
+function type_it(values, result) {
+  values.forEach( value => (
+    it(`returns ${prettyFormat(result)} for ${prettyFormat(value)}`, () => {
+      expect(getType(Boolean).name).toBe(BooleanType.name);
+    })
+  ));
+} 
+
+class MyClass {}
+
+type_it([Boolean, true, false], BooleanType);
+type_it([Number, 0, -1], NumberType);
+type_it([Object, {}], ObjectType);
+type_it([String, ""], StringType);
+type_it([Array, [], new Array()], ArrayType);
+type_it([MyClass], MyClass);

--- a/tests/utils/is-primitive.test.js
+++ b/tests/utils/is-primitive.test.js
@@ -1,29 +1,28 @@
 import 'jest';
 
 import isPrimitive from '../../src/utils/is-primitive';
-import * as MS from '../../src';
 
 describe('utils/is-primitive', () => {
   it('returns true for Number', () => {
-    expect(isPrimitive(MS.Number)).toBe(true);
+    expect(isPrimitive(Number)).toBe(true);
   });
   it('returns true for Object', () => {
-    expect(isPrimitive(MS.Object)).toBe(true);
+    expect(isPrimitive(Object)).toBe(true);
   });
   it('returns true for Array', () => {
-    expect(isPrimitive(MS.Array)).toBe(true);
+    expect(isPrimitive(Array)).toBe(true);
   });
   it('returns true for Boolean', () => {
-    expect(isPrimitive(MS.Boolean)).toBe(true);
+    expect(isPrimitive(Boolean)).toBe(true);
   });
   it('returns true for String', () => {
-    expect(isPrimitive(MS.String)).toBe(true);
+    expect(isPrimitive(String)).toBe(true);
   });
   it('returns false for a composed object', () => {
     expect(
       isPrimitive(
         class {
-          foo = MS.String;
+          foo = String;
         }
       )
     ).toBe(false);

--- a/tests/utils/transitions-for.test.js
+++ b/tests/utils/transitions-for.test.js
@@ -1,83 +1,70 @@
 import 'jest';
 import { map } from 'funcadelic';
-import * as MS from '../../src';
+import '../../src/typeclasses';
 import transitionsFor from '../../src/utils/transitions-for';
 
-describe('utils/transitions-for', () => {
-  describe('Array', () => {
-    let transitions = transitionsFor(MS.Array);
-    it('has transitions', () => {
-      expect(transitions).toMatchObject({
-        set: expect.any(Function),
-        push: expect.any(Function),
-      });
-    });
+it('gets array transitions', () => {
+  expect(transitionsFor(Array)).toMatchObject({
+    set: expect.any(Function),
+    push: expect.any(Function),
   });
-  describe('String', () => {
-    let transitions = transitionsFor(MS.String);
-    it('has transitions', () => {
-      expect(transitions).toMatchObject({
-        set: expect.any(Function),
-        concat: expect.any(Function),
-      });
-    });
+});
+
+it('get string transitions', () => {
+  expect(transitionsFor(String)).toMatchObject({
+    set: expect.any(Function),
+    concat: expect.any(Function),
   });
-  describe('Number', () => {
-    let transitions = transitionsFor(MS.Number);
-    it('has transitions', () => {
-      expect(transitions).toMatchObject({
-        set: expect.any(Function),
-        increment: expect.any(Function),
-      });
-    });
+});
+
+it('gets number transitions', () => {
+  expect(transitionsFor(Number)).toMatchObject({
+    set: expect.any(Function),
+    increment: expect.any(Function),
   });
-  describe('Boolean', () => {
-    let transitions = transitionsFor(MS.Boolean);
-    it('has transitions', () => {
-      expect(transitions).toMatchObject({
-        set: expect.any(Function),
-        toggle: expect.any(Function),
-      });
-    });
-    it('does not have initialize', () => {
-      expect(transitions.initialize).not.toBeDefined();
-    });
+});
+
+it('gets boolean transitions', () => {
+  expect(transitionsFor(Boolean)).toMatchObject({
+    set: expect.any(Function),
+    toggle: expect.any(Function),
   });
-  describe('Object', () => {
-    let transitions = transitionsFor(MS.Object);
-    it('has transitions', () => {
-      expect(transitions).toMatchObject({
-        set: expect.any(Function),
-        assign: expect.any(Function),
-      });
-    });
+});
+
+it('gets object transitions', () => {
+  expect(transitionsFor(Object)).toMatchObject({
+    set: expect.any(Function),
+    assign: expect.any(Function),
   });
-  describe('Custom Class', () => {
-    let transitions = transitionsFor(
-      class MyClass {
-        string = MS.String;
-        action() {}
-      }
-    );
-    it('has transitions', () => {
-      expect(transitions).toMatchObject({
-        set: expect.any(Function),
-        merge: expect.any(Function),
-      });
-    });
-    it('has custom transition', () => {
-      expect(transitions.action).toBeDefined();
-    });
+});
+
+class MyClass {
+  string = String;
+  action() {}
+}
+
+it('gets composed type transitions', () => {
+  expect(transitionsFor(
+    MyClass
+  )).toMatchObject({
+    set: expect.any(Function),
+    merge: expect.any(Function),
   });
-  describe('inhertied transitions', () => {
-    class Parent {
-      fromParent() {}
-    }
-    class Child extends Parent {}
-    it('are available on child class', () => {
-      expect(transitionsFor(Child)).toMatchObject({
-        fromParent: expect.any(Function),
-      });
-    });
+});
+
+it('gets custom transition', () => {
+  expect(transitionsFor(
+    MyClass
+  ).action).toBeDefined();
+});
+
+class Parent {
+  fromParent() {}
+}
+class Child extends Parent {}
+
+it('inherits transitions', () => {
+  expect(transitionsFor(Child)).toMatchObject({
+    fromParent: expect.any(Function),
   });
 });

--- a/tests/utils/transitions-for.test.js
+++ b/tests/utils/transitions-for.test.js
@@ -1,7 +1,7 @@
 import 'jest';
-
-import transitionsFor from '../../src/utils/transitions-for';
+import { map } from 'funcadelic';
 import * as MS from '../../src';
+import transitionsFor from '../../src/utils/transitions-for';
 
 describe('utils/transitions-for', () => {
   describe('Array', () => {


### PR DESCRIPTION
The goal of this PR is to simplify Microstates and remove concepts that make it weird in JavaScript ecosystem. These changes make Microstates more *boring* but this is a good thing. Here are all of the changes that this PR introduces.

1. Removes `this()` context in transitions'
2. Introduces type shifting with set
2. Removes MS.* namespace
3. Renames microstates factory to create and moves it to static method on `Microstate` class
4. Eliminates current as first argument in transitions

## Removes `this()` context in transitions

`this()` was cool because it provided an interesting API for type shifting in transitions, unfortunately it was not welcomed by people who we respect. Our friends raised concerns about support by languages like TypeScript and typeflow. We decided to remove `this()` in favour of `this` being a microstate for current type and value. For all intents and purposes `this()` and `this` are now equivalent because context is actually result of `this()`.

To call access other transitions from inside of a transition you can do,

```diff
class Car {
  speed = Number;
  increaseSpeed(amount) {
-    return this().speed.sum(amount);
+    return this.speed.sum(amount);
  }
}
```

## Type Shifting by returning a new microstate

Since `this()` API is no longer available, we need some other way to cause a node in microstate to change type. The `set` transition can now set the value and type of current node. 

```diff
+ import { create } from 'microstates';

  class Line {
    a = Number;
    add(b) {
      let { a } = this.state;
-     return this(Corner, { a, b }); 
+     return create(Corner, { a, b });
    }
  }

  class Corner extends Line {
    b = Number;
  }
```

## Removes MS.* namespace

We've been asked `MS.Number` and not just `Number`. Good point we said, so there is no more namespace. We're mapping JavaScript types internal types that have transitions. It makes the API surface much smaller and more ergonomic.

```diff
- import * as MS from 'microstates';

class Counter {
-  count = MS.Number
+  count = Number
}

```

## Renames microstates factory to create and moves it to static method on `Microstate` class

We've been asked why can't I just do `new Microstate`. This won't work because `Microstate` constructor expects a tree. To the lay the foundation for the hopeful future where microstates will work like a class, we'll making the microstates factory similar to `Object.create`. The factory now lives on `Microstate` class and is appropriately called `Microstate.class`.

To create  microstate, the developer has to,
```js
import Microstate from 'microstates';

Microstate.create(Number, 42);
``` 

In the future, we'll be able to create a babel plugin that will transpile something like,

```js
import Microstate from 'microstates';

state Modal {
  isOpen = Boolean;
}

let modal = new Modal({ isOpen: true });
```

to something that'll be equivalent of 

```js

class Modal {
}

let modal = new Microstate.create(Modal, { isOpen: true });
```

Something of that nature, but likely somewhat different.

## Eliminates current as first argument in transitions

Originally, we designed transitions like Redux reducers because we thought that reducers provided a good point of reference for how transitions work. As we added comparability and batched transitions, it no longer made sense. In addition, some respected friends suggested to change this because it's weird that a method that they define receives different arguments than they specified. 

The first argument was not being used and it was not helpful to make these functions without context. Now that transition context is a microstate, it's very easy to make the state accessible off the `this.state` property. 

```diff
class Boolean {
-  toggle(current) {
-      return !current;
+  toggle() {
+     return !this.state;
    }
}
```

---

This PR is created against the `tree-structure-and-lenses` branch. After that branch is merged, this PR should be changed to master before merging.