### PR TITLE
Fixed the functor

### DIFF
--- a/src/structure.js
+++ b/src/structure.js
@@ -136,6 +136,7 @@ class Node {
 
       let nextTree = set(lensTree(path), graft(path, nextLocalTree), tree);
       let nextValue = set(lensPath(path), nextLocalValue, value);
+      
       return { tree: nextTree, value: nextValue };
     }, transitionsFor(Type));
 

--- a/src/typeclasses.js
+++ b/src/typeclasses.js
@@ -1,16 +1,38 @@
-import { Applicative, Functor, map } from 'funcadelic';
+import { Applicative, Functor, map, append } from 'funcadelic';
 import { Monad, flatMap } from './monad';
 import Microstate from './microstate';
 import { reveal } from './utils/secret';
 import Tree from './utils/tree';
 import thunk from './thunk';
 
+function invoke({ method, args, value, tree}) {
+  let nextValue = method.apply(new Microstate(tree, value), args);
+  if (nextValue instanceof Microstate) {
+    return reveal(nextValue);
+  } else {
+    return { tree, value: nextValue };
+  }
+}
+
 Functor.instance(Microstate, {
   map(fn, microstate) {
     let { tree, value } = reveal(microstate);
-    let structure = map(node => fn(node), tree);
-    return new Microstate(structure, value);
-  },
+
+    // tree of transitions
+    let next = map(node => {
+      let transitions = node.transitionsAt(value, tree, invoke);      
+      return map(transition => {
+        return (...args) => {
+          let { tree, value } = transition(...args);
+          return new Microstate(tree, value);
+        };
+      }, transitions)
+    }, tree);
+
+    let mapped = map(transitions => map(fn, transitions), next);
+
+    return append(microstate, mapped.collapsed);
+  }
 });
 
 Functor.instance(Tree, {

--- a/tests/microstate.test.js
+++ b/tests/microstate.test.js
@@ -6,23 +6,6 @@ it('exports create', function() {
   expect(create).toBeInstanceOf(Function);
 });
 
-it('throws an error when a transition called state is defined', () => {
-  expect(function() {
-    create(
-      class MyClass {
-        state() {}
-      }
-    );
-  }).toThrowError(
-    `You can not use 'state' as transition name because it'll conflict with state property on the microstate.`
-  );
-});
-it('throws an error when state property is set', () => {
-  expect(function() {
-    create(Number).state = 10;
-  }).toThrowError(`Setting state property will not do anything useful. Please don't do this.`);
-});
-
 describe('valueOf', () => {
   let ms;
   beforeEach(() => {

--- a/tests/typeclasses.test.js
+++ b/tests/typeclasses.test.js
@@ -6,6 +6,11 @@ import Microstate, { create }  from "microstates";
 describe("typeclasses", () => {
   class Home {
     city = String;
+    population = Number;
+
+    grow(size) {
+      return this.population.set(size);
+    }
   }
 
   class Person {
@@ -13,36 +18,71 @@ describe("typeclasses", () => {
     home = Home;
   }
 
-  let simple, complex;
-  beforeEach(() => {
-    simple = create(Number, 10);
-    complex = create(Person, { name: "Taras", home: { city: "Toronto" } });
+  describe('mapped object', () => {
+    let fn, mapped;
+    beforeEach(() => {
+      fn = jest.fn().mockImplementation(v => v);
+      let ms = create(Person, { name: "Taras", home: { city: "Toronto" } });
+      mapped = map(fn, ms);
+    });
+  
+    it('has composed objects', () => {
+      // console.log(typeof mapped.home)/
+      expect(mapped.home).toBeDefined()
+      expect(mapped.home.set).toBeDefined();
+    });
+  
+    it('kept the valueOf', () => {
+      expect(mapped.valueOf()).toEqual({ name: "Taras", home: { city: "Toronto" } });
+    });
   })
 
-  describe("functor", function() {  
-    let simpleUnchanged, complexUnchanged;
-    beforeEach(() => {  
-      simpleUnchanged = map(node => node, simple);
-      complexUnchanged = map(node => node, complex);
-    });
-  
-    it("is different than original object", () => {
-      expect(simpleUnchanged).not.toBe(simple);
-      expect(complexUnchanged).not.toBe(complex);
-    });
-  
-    it("returns an instance of microstate", () => {
-      expect(simpleUnchanged).toBeInstanceOf(Microstate);
-      expect(complexUnchanged).toBeInstanceOf(Microstate);
-    });
-  
-    it("unchangd maintains same value", function() {
-      expect(simpleUnchanged.state).toBe(10);
-      expect(complexUnchanged.state).toEqual({
-        name: "Taras",
-        home: { city: "Toronto" }
+  describe('callback', function() {
+    let fn, mapped, m1, m2;
+    beforeEach(() => {
+      fn = jest.fn(transition => (...args) => {
+        let next = transition(...args);
+        return map(fn, next);
       });
+
+      let ms = create(Person, { name: "Taras", home: { city: "Toronto" } });
+
+      mapped = map(fn, ms);
+
+      m1 = mapped.home.city.set('Austin');
+      m2 = m1.name.set('Charles');
+    });
+
+    it('invoked callback for each transition', () => {
+      expect(fn.mock.calls[0][0]).toBeInstanceOf(Function);
+      expect(fn.mock.calls[1][0]).toBeInstanceOf(Function);
     });
   });
 
+  describe('setState', function() {
+    let last, setState = ms => last = ms;
+
+    beforeEach(() => {
+      last = null;
+
+      let ms = create(Person, { name: "Taras", home: { city: "Toronto" } });
+
+      let setStateOnTransition = transition => (...args) => {
+        let next = transition(...args);
+        let mapped = map(setStateOnTransition, next);
+        setState(mapped);
+        return mapped;
+      };
+
+      setState(map(setStateOnTransition, ms));
+
+      last.name.set('Charles');
+      last.home.city.set('Austin');
+      last.home.grow(1);
+    });
+
+    it('accumulated changed', function() {
+      expect(last.valueOf()).toEqual({ name: 'Charles', home: { city: 'Austin', population: 1 }});
+    });
+  });
 });


### PR DESCRIPTION
This PR makes it possible to map the microstate as a correct function. Mapping the microstate will return a new microstate. The mapper function will receive a transition, calling this transition will return the next microstate. 

```js
import { map } from 'funcadelic';
import { create } from 'microstates';

let m = create(Number, 42);

function transitionLogger(transition) {
  return (...args) => {
    let next = transition(...args);
    console.log('next microstate is', next);
    return map(transitionLogger, next);
  };
}

let mapped = map(transitionLogger, m); 

let m1 = mapped.increment();
// => next microstate is Microstate<43>

m1.increment();
// => next microstate is Microstate<44>
```