### PR TITLE
Type-shifting in constructor with `create`

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,9 +368,9 @@ class Session {
 
   constructor(state) {
     if (state) {
-      return new AuthenticatedSession(state);
+      return create(AuthenticatedSession, state);
     } else {
-      return new AnonymousSession(state);
+      return create(AnonymousSession, state);
     }
   }
 }

--- a/src/structure.js
+++ b/src/structure.js
@@ -7,6 +7,7 @@ import transitionsFor from './utils/transitions-for';
 import { reveal } from './utils/secret';
 import { toType } from './types';
 import isSimple  from './is-simple';
+import Microstate from './microstate';
 
 const { assign } = Object;
 
@@ -19,7 +20,14 @@ function analyzeType(value) {
     let InitialType = node.Type;
     let valueAt = node.valueAt(value);
     let instance = new InitialType(valueAt);
-    let Type = toType(instance.constructor);
+    
+    let Type; 
+    if (instance instanceof Microstate) {
+      let { tree } = reveal(instance);
+      Type = tree.data.Type;
+    } else {
+      Type  = toType(instance.constructor);
+    }
 
     return new Tree({
       data: () => Type === InitialType ? node : append(node, { Type }),

--- a/tests/examples/authentication.test.js
+++ b/tests/examples/authentication.test.js
@@ -5,9 +5,9 @@ class Session {
   content = null;
   constructor(state) {
     if (state) {
-      return new AuthenticatedSession(state);
+      return create(AuthenticatedSession, state);
     } else {
-      return new AnonymousSession(state);
+      return create(AnonymousSession, state);
     }
   }
 }


### PR DESCRIPTION
This PR changes how type shifting is done from the constructor. Previously, it was done by returning a new instance of a class that you're shifting to. This caused confusion because we don't have `new` in our API. With this PR, type shifting is done by returning a new microstate from the constructor.