### PR TITLE
Introducing `static create` method for initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,11 +368,11 @@ import { create } from 'microstates';
 class Session {
   content = null;
 
-  static create(state) {
-    if (state) {
-      return create(AuthenticatedSession, state);
+  static create(session) {
+    if (session) {
+      return create(AuthenticatedSession, session);
     } else {
-      return create(AnonymousSession, state);
+      return create(AnonymousSession);
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -358,9 +358,9 @@ create(MyComponent).modal.show('Hello World', 'Rise and shine!').state;
 
 # Changing structure
 
-Microstates can change their own structure using custom transitions. This is useful when you're
-modeling state machines or want to be able to change the shape of the state after a transition. To
-change the structure of a microstate you replace it with new microstate in a custom transition.
+When modeling state machines, it's often helpful to be able to initialize into a particular
+state based on value. This can be accomplised by adding a static `create` method. This method
+should return the next state that you want the node to initialize into.
 
 ```js
 import { create } from 'microstates';
@@ -368,7 +368,7 @@ import { create } from 'microstates';
 class Session {
   content = null;
 
-  constructor(state) {
+  static create(state) {
     if (state) {
       return create(AuthenticatedSession, state);
     } else {
@@ -376,8 +376,13 @@ class Session {
     }
   }
 }
+```
 
-class AuthenticatedSession {
+Once your state is initialized, you can return new microstates from transition to transition
+time of the node that the transition is attached to.
+
+```js
+class AuthenticatedSession extends Session {
   isAuthenticated = true;
   content = Object;
 
@@ -386,7 +391,7 @@ class AuthenticatedSession {
   }
 }
 
-class AnonymousSession {
+class AnonymousSession extends Session {
   content = null;
   isAuthenticated = false;
   authenticate(user) {

--- a/src/structure.js
+++ b/src/structure.js
@@ -28,8 +28,12 @@ function analyzeType(value) {
     let instance = new InitialType(valueAt);
 
     if (instance instanceof Microstate) {
-      let { tree } = reveal(instance);
-      return graft(node.path, tree);
+      let { tree , value } = reveal(instance);
+      let shift = new ShiftNode(tree.data, value);
+      return graft(node.path, new Tree({
+        data: () => shift,
+        children: () => tree.children
+      }));
     } else {
       let Type = toType(InitialType);
       return new Tree({
@@ -183,5 +187,16 @@ class Node {
 
       return { tree: nextTree, value: nextValue };
     }, transitionsFor(Type));
+  }
+}
+
+class ShiftNode extends Node {
+  constructor({ Type, path }, value) {
+    super(Type, path);
+    assign(this, { value });
+  }
+
+  valueAt() {
+    return this.value;
   }
 }

--- a/src/structure.js
+++ b/src/structure.js
@@ -32,15 +32,11 @@ function analyzeType(value) {
     if (instance instanceof Microstate) {
       let { tree , value } = reveal(instance);
 
-      if (tree.data.Type === Type && value === valueAt) {
-        return graft(node.path, tree);
-      } else {
-        let shift = new ShiftNode(tree.data, value);
-        return graft(node.path, new Tree({
-          data: () => shift,
-          children: () => tree.children
-        }));
-      }
+      let shift = new ShiftNode(tree.data, value);
+      return graft(node.path, new Tree({
+        data: () => shift,
+        children: () => tree.children
+      }));
     }
 
     return new Tree({

--- a/src/structure.js
+++ b/src/structure.js
@@ -33,7 +33,7 @@ function analyzeType(value) {
       let { tree , value } = reveal(instance);
 
       if (tree.data.Type === Type && value === valueAt) {
-        return tree;
+        return graft(node.path, tree);
       } else {
         let shift = new ShiftNode(tree.data, value);
         return graft(node.path, new Tree({

--- a/src/structure.js
+++ b/src/structure.js
@@ -25,9 +25,14 @@ function analyzeType(value) {
   return (node) => {
     let InitialType = desugar(node.Type);
     let valueAt = node.valueAt(value);
-    let instance = new InitialType(valueAt);
+    
+    if (InitialType !== Object && InitialType.hasOwnProperty('create')) {
 
-    if (instance instanceof Microstate) {
+      let instance = InitialType.create(valueAt);
+      if (!(instance instanceof Microstate)) {
+        throw new Error(`${InitialType.name}.create must return a Microstate instance instead returned ${instance}`);
+      }
+
       let { tree , value } = reveal(instance);
       let shift = new ShiftNode(tree.data, value);
       return graft(node.path, new Tree({

--- a/tests/examples/authentication.test.js
+++ b/tests/examples/authentication.test.js
@@ -3,12 +3,11 @@ import { create } from 'microstates';
 
 class Session {
   content = null;
-  static create(state) {
-    if (state) {
-      return create(AuthenticatedSession, state);
-    } else {
-      return create(AnonymousSession, state);
+  static create(session) {
+    if (session) {
+      return create(AuthenticatedSession, session);
     }
+    return create(AnonymousSession);
   }
 }
 

--- a/tests/examples/authentication.test.js
+++ b/tests/examples/authentication.test.js
@@ -3,7 +3,7 @@ import { create } from 'microstates';
 
 class Session {
   content = null;
-  constructor(state) {
+  static create(state) {
     if (state) {
       return create(AuthenticatedSession, state);
     } else {
@@ -12,7 +12,7 @@ class Session {
   }
 }
 
-class AuthenticatedSession {
+class AuthenticatedSession extends Session {
   isAuthenticated = true;
   content = Object;
 
@@ -21,7 +21,7 @@ class AuthenticatedSession {
   }
 }
 
-class AnonymousSession {
+class AnonymousSession extends Session {
   content = null;
   isAuthenticated = false;
   authenticate(user) {

--- a/tests/shallow-composition.test.js
+++ b/tests/shallow-composition.test.js
@@ -5,6 +5,7 @@ class Modal {
   name = String;
   isOpen = Boolean;
 }
+
 describe('types', () => {
   describe('value', () => {
     let ms;

--- a/tests/sugar.test.js
+++ b/tests/sugar.test.js
@@ -2,6 +2,15 @@ import 'jest';
 
 import desugar, { isSugar } from '../src/desugar';
 import types, { params } from '../src/types';
+import { any } from '../src/types/parameters';
+
+it('detects [] as sugar', () => {
+  expect(isSugar([])).toBe(true);
+});
+
+it('detects {} as sugar', () => {
+  expect(isSugar({})).toBe(true);
+});
 
 it('detects [Type] as sugar', () => {
   expect(isSugar([Boolean])).toBe(true);
@@ -21,10 +30,22 @@ it('detects [[Number]] as sugar', function() {
   expect(isSugar([[Number]])).toBe(true);
 });
 
+it('converts [] into parameterized(Array)', () => {
+  let Parameterized = desugar([]);
+  expect(Parameterized.prototype).toBeInstanceOf(types.Array);
+  expect(params(Parameterized).T).toBe(any);
+});
+
 it('converts [Type] into parameterized(Array, Type)', () => {
   let Parameterized = desugar([Boolean]);
   expect(Parameterized.prototype).toBeInstanceOf(types.Array);
   expect(params(Parameterized).T).toBe(types.Boolean);
+});
+
+it('converts {} into parameterized(Object)', () => {
+  let Parameterized = desugar({});
+  expect(Parameterized.prototype).toBeInstanceOf(types.Object);
+  expect(params(Parameterized).T).toBe(any);
 });
 
 it('converts {Type} into parameterized(Object, Type)', () => {

--- a/tests/type-shifting.test.js
+++ b/tests/type-shifting.test.js
@@ -98,6 +98,28 @@ describe('type-shifting', () => {
       expect(drawing.state.shapes[2]).toBeInstanceOf(Triangle);            
     });
 
+    describe('can typeshift into parameterized type', () => {
+      class Container {
+        static create(content) {
+          if (Array.isArray(content)) {
+            return create([String], content);
+          } else {
+            return create({String}, content);
+          }
+        }
+      }
+      it('can initialize into a parameterized array', () => {
+        let array = Container.create(['a', 'b', 'c']);
+        expect(array.state).toMatchObject(['a', 'b', 'c']);
+        expect(array[0].concat).toBeInstanceOf(Function);
+      });
+      it('can initialize into a parameterized object', () => {
+        let object = Container.create({a: 'A', b: 'B', c: 'C'});
+        expect(object.state).toMatchObject({a: 'A', b: 'B', c: 'C'});
+        expect(object.a.concat).toBeInstanceOf(Function);
+      });
+    });
+
   });
 
   describe('transitions', function() {

--- a/tests/type-shifting.test.js
+++ b/tests/type-shifting.test.js
@@ -14,7 +14,6 @@ describe('type-shifting', () => {
       if (a) {
         return create(Line, { a });
       }
-      return create(Shape);
     }
   }
 
@@ -46,7 +45,7 @@ describe('type-shifting', () => {
   describe('create', function() {
 
     it('can initialize to itself', () => {
-      let shape = Shape.create();
+      let shape = create(Shape);
       expect(shape.state).toBeInstanceOf(Shape);
     });
 

--- a/tests/type-shifting.test.js
+++ b/tests/type-shifting.test.js
@@ -2,14 +2,23 @@ import 'jest';
 import { create } from 'microstates';
 
 describe('type-shifting', () => {
-  class Line {
+  class Shape {
+    constructor({ a, b, c }) {
+      if (a && b && c) {
+        return create(Triangle, { a, b, c });
+      }
+    }
+  }
+
+  class Line extends Shape {
     a = Number;
     add(b) {
       let { a } = this.state;
-      return create(Corner, { a, b });
+      return create(Angle, { a, b });
     }
   }
-  class Corner extends Line {
+
+  class Angle extends Line {
     a = Number;
     b = Number;
     add(c) {
@@ -17,45 +26,65 @@ describe('type-shifting', () => {
       return create(Triangle, { a, b, c });
     }
   }
-  class Triangle extends Corner {
+  
+  class Triangle extends Angle {
     c = Number;
   }
-  let ms = create(Line);
-  let line, corner, triangle;
-  beforeEach(() => {
-    line = ms.a.set(10);
-    corner = line.add(20);
-    triangle = corner.add(30);
-  });
-  it('constructs a line', () => {
-    expect(line.state).toBeInstanceOf(Line);
-    expect(line.state).toMatchObject({
-      a: 10,
+
+  describe('from constructor', () => {
+    it('can type shift to a Triangle', function() {
+      let triangle = create(Shape, { a: 10, b: 20, c: 10 });
+      expect(triangle.state).toBeInstanceOf(Triangle);
+      expect(triangle.state).toMatchObject({
+        a: 10,
+        b: 20,
+        c: 10
+      });
     });
-    expect(line.valueOf()).toEqual({ a: 10 });
+    // it('can type shift to Line', function() {
+    //   let line = create(Shape, { a: 10 });
+    //   expect(line.state).toBeInstanceOf(Line);
+    // });
   });
-  it('constructs a Corner', () => {
-    expect(corner.state).toBeInstanceOf(Corner);
-    expect(corner.state).toMatchObject({
-      a: 10,
-      b: 20,
+
+  describe('transitions', function() {
+    let ms = create(Line);
+    let line, corner, triangle;
+    beforeEach(() => {
+      line = ms.a.set(10);
+      corner = line.add(20);
+      triangle = corner.add(30);
     });
-    expect(corner.valueOf()).toEqual({ a: 10, b: 20 });
-  });
-  it('constructs a Triangle', () => {
-    expect(triangle.state).toBeInstanceOf(Triangle);
-    expect(triangle.state).toMatchObject({
-      a: 10,
-      b: 20,
-      c: 30,
+    it('constructs a line', () => {
+      expect(line.state).toBeInstanceOf(Line);
+      expect(line.state).toMatchObject({
+        a: 10,
+      });
+      expect(line.valueOf()).toEqual({ a: 10 });
     });
-    expect(triangle.valueOf()).toEqual({ a: 10, b: 20, c: 30 });
-  });
-  it('can be done down tree', () => {
-    let string = create(String, '100');
-    let cString = triangle.c.set(string)
-    expect(cString.state.c).toBe('100');
-    expect(cString.c.concat).toBeDefined();
+    it('constructs a Corner', () => {
+      expect(corner.state).toBeInstanceOf(Angle);
+      expect(corner.state).toMatchObject({
+        a: 10,
+        b: 20,
+      });
+      expect(corner.valueOf()).toEqual({ a: 10, b: 20 });
+    });
+    it('constructs a Triangle', () => {
+      expect(triangle.state).toBeInstanceOf(Triangle);
+      expect(triangle.state).toMatchObject({
+        a: 10,
+        b: 20,
+        c: 30,
+      });
+      expect(triangle.valueOf()).toEqual({ a: 10, b: 20, c: 30 });
+    });
+    it('can be done down tree', () => {
+      let string = create(String, '100');
+      let cString = triangle.c.set(string)
+      expect(cString.state.c).toBe('100');
+      expect(cString.c.concat).toBeDefined();
+    });
   });
 });
 

--- a/tests/type-shifting.test.js
+++ b/tests/type-shifting.test.js
@@ -14,6 +14,7 @@ describe('type-shifting', () => {
       if (a) {
         return create(Line, { a });
       }
+      return create(Shape);
     }
   }
 
@@ -43,6 +44,11 @@ describe('type-shifting', () => {
   }
 
   describe('create', function() {
+
+    it('can initialize to itself', () => {
+      let shape = Shape.create();
+      expect(shape.state).toBeInstanceOf(Shape);
+    });
 
     it('initializes to first type', () => {
       let triangle = Shape.create({a: 10, b: 20, c: 30 });
@@ -81,19 +87,6 @@ describe('type-shifting', () => {
           c: 30
         }
       });
-    });
-
-    it('throws an error when create does not return an instance of Shape', () => {
-      expect(() => {
-        class Alphabet {
-          a = class Letter {
-            static create() {
-  
-            }
-          }
-        }
-        create(Alphabet).state.a
-      }).toThrowError(/Letter.create must return a Microstate instance instead returned undefined/);
     });
 
     it('supports being initialized in parameterized arrays', () => {

--- a/tests/type-shifting.test.js
+++ b/tests/type-shifting.test.js
@@ -98,7 +98,7 @@ describe('type-shifting', () => {
       expect(drawing.state.shapes[2]).toBeInstanceOf(Triangle);            
     });
 
-    describe('can typeshift into parameterized type', () => {
+    describe('can type-shift into a parameterized type', () => {
       class Container {
         static create(content) {
           if (Array.isArray(content)) {


### PR DESCRIPTION
When modeling state machines, it's necessary to be able to initialize into a particular
state based on value. Previously, this was accomplished by returning a microstate from the constructor. This lead to exceeds maximum call stack when destination type extended from type shifting class. 

This PR introduces a new convention which allows the developer to describe how a state should be initialized for a specific type. `create` method must return a microstate that represents the state that you want the state to initialize into or nothing.  The create method takes one argument which is any `value`.

```js
import { create } from 'microstates';

class Session {
  content = null;

  static create(session) {
    if (session) {
      return create(AuthenticatedSession, session);
    } else {
      return create(AnonymousSession);
    }
  }
}

class AuthenticatedSession extends Session {
  isAuthenticated = true;
  content = Object;

  logout() {
    return create(AnonymousSession);
  }
}

class AnonymousSession extends Session {
  content = null;
  isAuthenticated = false;

  authenticate(user) {
    return create(AuthenticatedSession, { content: user });
  }
}
```

The create method follows the same semantics as the constructor. When you return a microstate, it'll use the type and value in the microstate for `this` node. If you return anything else, it'll ignore the result and create an empty instance of that type. 

One perk of this solution is that all types that extend from the root type will automatically get this create method. 