### PR TITLE
Install latest npm in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ node_js:
   - "6"
 
 install:
-  - npm i -g coveralls
+  - npm install -g npm@latest
+  - npm install -g coveralls
   - npm install
 
 script:


### PR DESCRIPTION
This PR changes the travis build to use latest version of npm for all node versions. There should really be no reason to use older versions of npm even with node 6.